### PR TITLE
feat(oyasai-menu): add special menus and optimize rendering

### DIFF
--- a/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/OyasaiMenu.kt
+++ b/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/OyasaiMenu.kt
@@ -35,6 +35,8 @@ class OyasaiMenu : JavaPlugin(), Listener {
   lateinit var macroEngine: MacroEngine
   lateinit var adminEngine: AdminEngine
   lateinit var guiEditorEngine: GuiEditorEngine
+  lateinit var parameterCommandEngine: ParameterCommandEngine
+  lateinit var specialMenuEngine: SpecialMenuEngine
 
   override fun onEnable() {
     saveDefaultConfig()
@@ -59,6 +61,8 @@ class OyasaiMenu : JavaPlugin(), Listener {
     macroEngine = MacroEngine(this)
     adminEngine = AdminEngine(this)
     guiEditorEngine = GuiEditorEngine(this)
+    parameterCommandEngine = ParameterCommandEngine(this)
+    specialMenuEngine = SpecialMenuEngine(this)
 
     menuLoader.loadAll()
     shopLoader.loadAll()
@@ -101,6 +105,8 @@ class OyasaiMenu : JavaPlugin(), Listener {
             macroEngine,
             adminEngine,
             guiEditorEngine,
+            parameterCommandEngine,
+            specialMenuEngine,
             announcementManager,
             this)
         .forEach { server.pluginManager.registerEvents(it, this) }

--- a/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/engine/ActionEngine.kt
+++ b/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/engine/ActionEngine.kt
@@ -70,6 +70,23 @@ class ActionEngine(private val plugin: OyasaiMenu) {
             .runTaskLater(plugin, Runnable { plugin.popupMenuEngine.open(player, target) }, 1L)
       }
 
+      ActionType.OPEN_SPECIAL -> {
+        val target = action.getString("target")
+        if (target.isEmpty()) {
+          plugin.logger.warning("open_special にターゲットが未指定。")
+          return
+        }
+        Bukkit.getScheduler()
+            .runTaskLater(
+                plugin, Runnable { plugin.specialMenuEngine.open(player, target, action) }, 1L)
+      }
+
+      ActionType.PARAM_COMMAND -> {
+        Bukkit.getScheduler()
+            .runTaskLater(
+                plugin, Runnable { plugin.parameterCommandEngine.open(player, action) }, 1L)
+      }
+
       ActionType.RUN_COMMAND,
       ActionType.CONSOLE_CMD -> {
         val cmd = applyPlaceholders(player, action.getString("command"))

--- a/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/engine/MenuEngine.kt
+++ b/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/engine/MenuEngine.kt
@@ -2,6 +2,8 @@ package com.github.sahyuya.oyasaiMenu.engine
 
 import com.github.sahyuya.oyasaiMenu.OyasaiMenu
 import com.github.sahyuya.oyasaiMenu.manager.CooldownManager
+import com.github.sahyuya.oyasaiMenu.manager.EconomyManager
+import com.github.sahyuya.oyasaiMenu.manager.TokenCurrencyManager
 import com.github.sahyuya.oyasaiMenu.model.MenuDefinition
 import com.github.sahyuya.oyasaiMenu.model.MenuItemDefinition
 import com.github.sahyuya.oyasaiMenu.model.PlayerMenuState
@@ -12,7 +14,6 @@ import com.github.sahyuya.oyasaiMenu.util.ItemVisuals
 import com.github.sahyuya.oyasaiMenu.util.PlayerAccess
 import me.clip.placeholderapi.PlaceholderAPI
 import org.bukkit.Bukkit
-import org.bukkit.Material
 import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
@@ -20,37 +21,26 @@ import org.bukkit.event.inventory.InventoryClickEvent
 import org.bukkit.event.inventory.InventoryCloseEvent
 import org.bukkit.inventory.Inventory
 import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.meta.SkullMeta
 
-/**
- * MenuEngine
- *
- * 変更点:
- * - openMenu() の root フォールバック判定を Elvis+if から when 式に変更 root.yml が存在しない・スキップされていても必ず rootFallback
- *   を使用する
- * - staticCache (未使用) を削除
- * - clearCache() はプレイヤー状態のみリセット
- */
 class MenuEngine(private val plugin: OyasaiMenu) : Listener {
 
   private val playerStates: MutableMap<String, PlayerMenuState> = mutableMapOf()
+  private var cachedTpsAtMillis: Long = 0L
+  private var cachedTps: Double = 20.0
 
   private val rootFallback =
       MenuDefinition(id = "root", title = "&8✦ おやさい鯖 メニュー ✦", size = 54, items = emptyMap())
 
   fun openMenu(player: Player, menuId: String, page: Int = 0) {
     val menuDef: MenuDefinition =
-        if (menuId == "root") {
-          rootFallback
-        } else {
-          val loaded =
-              plugin.menuLoader.getMenu(menuId)
-                  ?: run {
-                    player.sendMessage(c("&cメニューが見つかりません: $menuId"))
-                    plugin.logger.warning("存在しないメニューID: $menuId (player=${player.name})")
-                    return
-                  }
-          loaded
-        }
+        plugin.menuLoader.getMenu(menuId)
+            ?: if (menuId == "root") rootFallback
+            else {
+              player.sendMessage(c("&cメニューが見つかりません: $menuId"))
+              plugin.logger.warning("存在しないメニューID: $menuId (player=${player.name})")
+              return
+            }
     val inventory = buildInventory(player, menuDef)
     player.openInventory(inventory)
     playerStates[player.uniqueId.toString()] = PlayerMenuState(menuId = menuId, page = page)
@@ -67,23 +57,9 @@ class MenuEngine(private val plugin: OyasaiMenu) : Listener {
     event.isCancelled = true
     if (CooldownManager.isClickOnCooldown(player.uniqueId)) return
     val slot = event.rawSlot
-    if (state.menuId == "root" && slot in 45..53) {
-      when (slot) {
-        45 -> {
-          player.performCommand("dp")
-          player.playSound(player.location, org.bukkit.Sound.UI_BUTTON_CLICK, 0.5f, 1f)
-        }
-        else -> {
-          val entry = NavBar.entries.find { it.slot == slot }
-          if (entry != null)
-              Bukkit.getScheduler()
-                  .runTaskLater(
-                      plugin, Runnable { plugin.popupMenuEngine.open(player, entry.popupId) }, 1L)
-        }
-      }
-      return
-    }
-    val menuDef = plugin.menuLoader.getMenu(state.menuId) ?: return
+    val menuDef =
+        plugin.menuLoader.getMenu(state.menuId)
+            ?: if (state.menuId == "root") rootFallback else return
     val itemDef = menuDef.items.values.find { it.slot == slot } ?: return
     if (itemDef.icon.isAir) return
     if (!PlayerAccess.hasRequirement(player, itemDef.permission)) return
@@ -96,63 +72,122 @@ class MenuEngine(private val plugin: OyasaiMenu) : Listener {
   }
 
   private fun buildInventory(player: Player, menuDef: MenuDefinition): Inventory {
-    val title = applyPlaceholders(player, menuDef.title)
+    val context = PlaceholderContext(player)
+    val title = applyPlaceholders(menuDef.title, context)
     val inv = Bukkit.createInventory(null, menuDef.size, comp(title))
     menuDef.items.values.forEach { itemDef ->
       if (itemDef.icon.isAir) return@forEach
       if (!PlayerAccess.hasRequirement(player, itemDef.permission)) return@forEach
-      if (itemDef.slot < menuDef.size) inv.setItem(itemDef.slot, buildItemStack(player, itemDef))
-    }
-    if (menuDef.id == "root") {
-      val emptyGlass = makeGlass(Material.GRAY_STAINED_GLASS_PANE, " ")
-      for (i in 0..44) inv.setItem(i, emptyGlass)
-      val ann = plugin.announcementManager.getAnnouncements().firstOrNull()
-      if (ann != null) {
-        val glass = makeGlass(Material.GRAY_STAINED_GLASS_PANE, ann.title, ann.body)
-        for (i in 0..44) inv.setItem(i, glass)
-      }
-      NavBar.apply(inv, player, plugin, activeSlot = -1)
+      if (itemDef.slot < menuDef.size)
+          inv.setItem(itemDef.slot, buildItemStack(player, itemDef, context))
     }
     return inv
   }
 
-  private fun makeGlass(mat: Material, name: String, lore: List<String> = emptyList()): ItemStack {
-    val item = ItemStack(mat)
-    val meta = item.itemMeta!!
-    meta.displayName(comp(name))
-    if (lore.isNotEmpty()) meta.lore(lore.map { comp(it) })
-    item.itemMeta = meta
-    return item
-  }
-
-  private fun buildItemStack(player: Player, itemDef: MenuItemDefinition): ItemStack {
+  private fun buildItemStack(
+      player: Player,
+      itemDef: MenuItemDefinition,
+      context: PlaceholderContext
+  ): ItemStack {
     val item: ItemStack =
         when {
           itemDef.customTexture != null -> CustomHead.get(itemDef.customTexture)
           else -> ItemStack(itemDef.icon)
         }
     val meta = item.itemMeta ?: return item
-    meta.displayName(comp(applyPlaceholders(player, itemDef.name)))
-    val lore = itemDef.lore.map { comp(applyPlaceholders(player, it)) }
+    if (meta is SkullMeta && itemDef.customTexture == null) {
+      meta.owningPlayer = player
+    }
+    meta.displayName(comp(applyPlaceholders(itemDef.name, context)))
+
+    val lore =
+        itemDef.lore
+            .flatMap { line ->
+              if (line == "%announcement_body%") context.announcementBody else listOf(line)
+            }
+            .map { comp(applyPlaceholders(it, context)) }
     if (lore.isNotEmpty()) meta.lore(lore)
+
     ItemVisuals.applyEnchantVisual(meta, itemDef.enchanted)
     item.itemMeta = meta
     return item
   }
 
   fun applyPlaceholders(player: Player, text: String): String {
-    var result =
-        text
-            .replace("%player%", player.name)
-            .replace("%player_name%", player.name)
-            .replace("%online%", Bukkit.getOnlinePlayers().size.toString())
-            .replace("%server_tps%", String.format("%.2f", Bukkit.getTPS()[0]))
-    if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI"))
-        result = PlaceholderAPI.setPlaceholders(player, result)
+    return applyPlaceholders(text, PlaceholderContext(player))
+  }
+
+  fun getCachedTps(): Double {
+    val now = System.currentTimeMillis()
+    if (now - cachedTpsAtMillis >= 1000L) {
+      cachedTps = Bukkit.getTPS()[0]
+      cachedTpsAtMillis = now
+    }
+    return cachedTps
+  }
+
+  private fun applyPlaceholders(text: String, context: PlaceholderContext): String {
+    if (text.isEmpty()) return text
+
+    var result = text
+    if (result.contains("%player%")) result = result.replace("%player%", context.player.name)
+    if (result.contains("%player_name%"))
+        result = result.replace("%player_name%", context.player.name)
+    if (result.contains("%online%")) result = result.replace("%online%", context.onlinePlayers)
+    if (result.contains("%server_tps%"))
+        result = result.replace("%server_tps%", context.tpsTwoDecimals)
+    if (result.contains("%tps%")) result = result.replace("%tps%", context.tpsTwoDecimals)
+    if (result.contains("%dp_level%")) result = result.replace("%dp_level%", context.dpLevel)
+    if (result.contains("%money%")) result = result.replace("%money%", context.balance)
+    if (result.contains("%tokens%")) result = result.replace("%tokens%", context.tokens)
+    if (result.contains("%announcement_title%"))
+        result = result.replace("%announcement_title%", context.announcementTitle)
+    for (index in 0 until 10) {
+      val key = "%announcement_line_${index + 1}%"
+      if (result.contains(key)) result = result.replace(key, context.announcementLine(index))
+    }
+    if (context.placeholderApiAvailable && result.contains('%'))
+        result = PlaceholderAPI.setPlaceholders(context.player, result)
     return result
   }
 
   fun getPlayerState(player: Player): PlayerMenuState? = playerStates[player.uniqueId.toString()]
 
   fun clearCache() = playerStates.clear()
+
+  private inner class PlaceholderContext(val player: Player) {
+    val placeholderApiAvailable: Boolean =
+        Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")
+    val onlinePlayers: String by
+        lazy(LazyThreadSafetyMode.NONE) { Bukkit.getOnlinePlayers().size.toString() }
+    val tpsTwoDecimals: String by
+        lazy(LazyThreadSafetyMode.NONE) { String.format("%.2f", getCachedTps()) }
+    val dpLevel: String by
+        lazy(LazyThreadSafetyMode.NONE) {
+          if (placeholderApiAvailable)
+              runCatching { PlaceholderAPI.setPlaceholders(player, "%dp_level%") }
+                  .getOrElse { "---" }
+          else "---"
+        }
+    val balance: String by
+        lazy(LazyThreadSafetyMode.NONE) {
+          if (EconomyManager.isAvailable) EconomyManager.format(EconomyManager.getBalance(player))
+          else "---"
+        }
+    val tokens: String by
+        lazy(LazyThreadSafetyMode.NONE) {
+          if (TokenCurrencyManager.isAvailable)
+              TokenCurrencyManager.format(TokenCurrencyManager.getTokens(player))
+          else "---"
+        }
+    private val announcement by
+        lazy(LazyThreadSafetyMode.NONE) {
+          plugin.announcementManager.getAnnouncements().firstOrNull()
+        }
+    val announcementTitle: String by lazy(LazyThreadSafetyMode.NONE) { announcement?.title ?: "" }
+    val announcementBody: List<String> by
+        lazy(LazyThreadSafetyMode.NONE) { announcement?.body ?: emptyList() }
+
+    fun announcementLine(index: Int): String = announcementBody.getOrNull(index) ?: ""
+  }
 }

--- a/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/engine/NavBar.kt
+++ b/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/engine/NavBar.kt
@@ -4,6 +4,7 @@ import com.github.sahyuya.oyasaiMenu.OyasaiMenu
 import com.github.sahyuya.oyasaiMenu.manager.EconomyManager
 import com.github.sahyuya.oyasaiMenu.manager.TokenCurrencyManager
 import com.github.sahyuya.oyasaiMenu.util.GuiUtil.comp
+import java.util.UUID
 import me.clip.placeholderapi.PlaceholderAPI
 import org.bukkit.Bukkit
 import org.bukkit.Material
@@ -16,6 +17,20 @@ import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.meta.SkullMeta
 
 object NavBar {
+
+  private const val PLAYER_STATS_CACHE_TTL_MILLIS = 1000L
+  private const val PLAYER_STATS_CACHE_SWEEP_MILLIS = 60_000L
+
+  private data class PlayerStatsSnapshot(
+      val createdAtMillis: Long,
+      val onlinePlayers: Int,
+      val tps: String,
+      val dpLevel: String,
+      val balance: String,
+      val tokens: String
+  )
+
+  private val playerStatsCache: MutableMap<UUID, PlayerStatsSnapshot> = mutableMapOf()
 
   data class NavEntry(
       val slot: Int,
@@ -123,26 +138,51 @@ object NavBar {
     val meta = skull.itemMeta as SkullMeta
     meta.owningPlayer = player
     meta.displayName(comp("&f${player.name}"))
-
-    // PlaceholderAPI 経由で %dp_level% を取得
-    val dpLevel =
-        if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
-          runCatching { PlaceholderAPI.setPlaceholders(player, "%dp_level%") }.getOrElse { "---" }
-        } else "---"
+    val stats = playerStats(player, plugin)
 
     meta.lore(
         listOf(
-            comp("&7オンライン: &e${Bukkit.getOnlinePlayers().size}&f人"),
-            comp("&7TPS: &a${String.format("%.1f", Bukkit.getTPS()[0])}"),
-            comp("&7DP: &b$dpLevel"),
-            comp(
-                "&7所持金: &6${if (EconomyManager.isAvailable) EconomyManager.format(EconomyManager.getBalance(player)) else "---"}"),
-            comp(
-                "&7ポイント: &3${if (TokenCurrencyManager.isAvailable) "${TokenCurrencyManager.format(TokenCurrencyManager.getTokens(player))}&fP" else "---"}"),
+            comp("&7オンライン: &e${stats.onlinePlayers}&f人"),
+            comp("&7TPS: &a${stats.tps}"),
+            comp("&7DP: &b${stats.dpLevel}"),
+            comp("&7所持金: &6${stats.balance}"),
+            comp("&7ポイント: &3${stats.tokens}"),
             comp(""),
             comp("&eクリックで自分のプロフィールへ")))
     skull.itemMeta = meta
     return skull
+  }
+
+  private fun playerStats(player: Player, plugin: OyasaiMenu): PlayerStatsSnapshot {
+    val now = System.currentTimeMillis()
+    playerStatsCache[player.uniqueId]?.let {
+      if (now - it.createdAtMillis < PLAYER_STATS_CACHE_TTL_MILLIS) return it
+    }
+
+    playerStatsCache.entries.removeIf {
+      now - it.value.createdAtMillis > PLAYER_STATS_CACHE_SWEEP_MILLIS
+    }
+
+    val dpLevel =
+        if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
+          runCatching { PlaceholderAPI.setPlaceholders(player, "%dp_level%") }.getOrElse { "---" }
+        } else "---"
+    val snapshot =
+        PlayerStatsSnapshot(
+            createdAtMillis = now,
+            onlinePlayers = Bukkit.getOnlinePlayers().size,
+            tps = String.format("%.1f", plugin.menuEngine.getCachedTps()),
+            dpLevel = dpLevel,
+            balance =
+                if (EconomyManager.isAvailable)
+                    EconomyManager.format(EconomyManager.getBalance(player))
+                else "---",
+            tokens =
+                if (TokenCurrencyManager.isAvailable)
+                    "${TokenCurrencyManager.format(TokenCurrencyManager.getTokens(player))}&fP"
+                else "---")
+    playerStatsCache[player.uniqueId] = snapshot
+    return snapshot
   }
 
   /** スロット 0〜44 の空きを指定ガラスで埋める (既存アイテムは上書きしない) */

--- a/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/engine/ParameterCommandEngine.kt
+++ b/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/engine/ParameterCommandEngine.kt
@@ -1,0 +1,425 @@
+package com.github.sahyuya.oyasaiMenu.engine
+
+import com.github.sahyuya.oyasaiMenu.OyasaiMenu
+import com.github.sahyuya.oyasaiMenu.model.MenuAction
+import com.github.sahyuya.oyasaiMenu.util.GuiUtil.c
+import com.github.sahyuya.oyasaiMenu.util.GuiUtil.comp
+import java.util.Locale
+import java.util.UUID
+import kotlin.math.roundToInt
+import org.bukkit.Bukkit
+import org.bukkit.Material
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.inventory.ClickType
+import org.bukkit.event.inventory.InventoryClickEvent
+import org.bukkit.event.player.AsyncPlayerChatEvent
+import org.bukkit.event.player.PlayerCommandPreprocessEvent
+import org.bukkit.inventory.Inventory
+import org.bukkit.inventory.InventoryHolder
+import org.bukkit.inventory.ItemFlag
+import org.bukkit.inventory.ItemStack
+
+class ParameterCommandEngine(private val plugin: OyasaiMenu) : Listener {
+
+  private val placeholderPattern = Regex("\\{([A-Za-z][A-Za-z0-9_.-]*)}")
+  private val pendingTextInput: MutableMap<UUID, PendingTextInput> = mutableMapOf()
+
+  fun open(player: Player, action: MenuAction) {
+    if (!player.isOp) {
+      player.sendMessage(c("&cこの可変コマンドはOP限定です。"))
+      return
+    }
+
+    val template = action.getString("command", action.getString("template"))
+    if (template.isBlank()) {
+      player.sendMessage(c("&c可変コマンドに command が設定されていません。"))
+      return
+    }
+    val specs = buildSpecs(action, template)
+    if (specs.isEmpty()) {
+      player.sendMessage(c("&c可変コマンドに {amount} のような入力枠がありません。"))
+      return
+    }
+    val values = specs.associate { it.name to it.defaultValue(player) }.toMutableMap()
+    openSession(player, ParamCommandSession(template, specs, values, action))
+  }
+
+  private fun openSession(player: Player, session: ParamCommandSession) {
+    val inv = Bukkit.createInventory(ParamCommandHolder(session), 54, comp("&8可変コマンド"))
+    render(inv, player, session)
+    player.openInventory(inv)
+  }
+
+  private fun render(inv: Inventory, player: Player, session: ParamCommandSession) {
+    inv.clear()
+    fill(inv, Material.GRAY_STAINED_GLASS_PANE)
+    inv.setItem(
+        0,
+        item(
+            Material.COMMAND_BLOCK,
+            "&b可変コマンド",
+            "&7OP限定で実行します",
+            "&7左/右クリック: 値を増減・切替",
+            "&7Shiftクリックまたは中クリック: 手入力"))
+    inv.setItem(
+        4,
+        item(
+            Material.PAPER,
+            "&f実行内容",
+            "&7テンプレート: &f${session.template}",
+            "&7現在: &e${expandCommand(player, session)}"))
+
+    val slots = valueSlots()
+    session.specs.take(slots.size).forEachIndexed { index, spec ->
+      inv.setItem(slots[index], paramItem(spec, session.values[spec.name] ?: ""))
+    }
+    inv.setItem(45, item(Material.LIME_CONCRETE, "&a実行", "&7現在の値でコマンドを実行します"))
+    inv.setItem(49, item(Material.LEVER, "&e初期値に戻す", "&7すべての値をデフォルトへ戻します"))
+    inv.setItem(53, item(Material.BARRIER, "&c閉じる", "&7何も実行せず閉じます"))
+  }
+
+  @EventHandler
+  fun onInventoryClick(event: InventoryClickEvent) {
+    val holder = event.inventory.holder as? ParamCommandHolder ?: return
+    val player = event.whoClicked as? Player ?: return
+    event.isCancelled = true
+    if (event.clickedInventory != event.inventory) return
+    if (!player.isOp) {
+      player.closeInventory()
+      player.sendMessage(c("&cこの可変コマンドはOP限定です。"))
+      return
+    }
+
+    val session = holder.session
+    when (event.rawSlot) {
+      45 -> {
+        val command = expandCommand(player, session)
+        if (session.action.getString("confirm", "false").toBoolean()) {
+          plugin.specialMenuEngine.openConfirmCommand(
+              player, command, executionMode(session.action))
+        } else {
+          player.closeInventory()
+          executeCommand(player, command, executionMode(session.action))
+        }
+      }
+      49 -> {
+        session.specs.forEach { session.values[it.name] = it.defaultValue(player) }
+        render(event.inventory, player, session)
+      }
+      53 -> player.closeInventory()
+      else -> {
+        val index = valueSlots().indexOf(event.rawSlot)
+        val spec = session.specs.getOrNull(index) ?: return
+        if (event.click == ClickType.MIDDLE ||
+            event.click == ClickType.SHIFT_LEFT ||
+            event.click == ClickType.SHIFT_RIGHT) {
+          startTextInput(player, session, spec)
+          return
+        }
+        adjustValue(player, session, spec, event.click)
+        render(event.inventory, player, session)
+      }
+    }
+  }
+
+  @EventHandler
+  fun onCommandWhilePendingInput(event: PlayerCommandPreprocessEvent) {
+    val pending = pendingTextInput[event.player.uniqueId] ?: return
+    event.isCancelled = true
+    finishTextInput(event.player, pending, event.message)
+  }
+
+  @EventHandler
+  fun onChat(event: AsyncPlayerChatEvent) {
+    val player = event.player
+    val pending = pendingTextInput[player.uniqueId] ?: return
+    event.isCancelled = true
+    finishTextInput(player, pending, event.message)
+  }
+
+  private fun finishTextInput(player: Player, pending: PendingTextInput, rawText: String) {
+    val text = normalizeTypedInput(rawText)
+    Bukkit.getScheduler()
+        .runTask(
+            plugin,
+            Runnable {
+              if (text.equals("cancel", ignoreCase = true) || text == "キャンセル") {
+                player.sendMessage(c("&e入力をキャンセルしました。"))
+              } else {
+                val normalized = pending.spec.normalizeInput(text)
+                if (normalized == null) {
+                  player.sendMessage(c("&c値の形式が正しくありません: $text"))
+                } else {
+                  pending.session.values[pending.spec.name] = normalized
+                  player.sendMessage(c("&a${pending.spec.name} = $normalized"))
+                }
+              }
+              pendingTextInput.remove(player.uniqueId)
+              openSession(player, pending.session)
+            })
+  }
+
+  private fun startTextInput(player: Player, session: ParamCommandSession, spec: ParamSpec) {
+    pendingTextInput[player.uniqueId] = PendingTextInput(session, spec)
+    player.closeInventory()
+    player.sendMessage(c("&e${spec.name} の値をチャットに入力してください。cancel で中止。"))
+  }
+
+  private fun adjustValue(
+      player: Player,
+      session: ParamCommandSession,
+      spec: ParamSpec,
+      click: ClickType
+  ) {
+    val current = session.values[spec.name] ?: spec.defaultValue(player)
+    val direction =
+        when (click) {
+          ClickType.RIGHT -> -1
+          else -> 1
+        }
+    when (spec.type) {
+      ParamType.INT,
+      ParamType.FLOAT -> {
+        val base = current.toDoubleOrNull() ?: spec.defaultNumber
+        val multiplier =
+            if (click == ClickType.SHIFT_LEFT || click == ClickType.SHIFT_RIGHT) 10.0 else 1.0
+        val next = spec.clamp(base + spec.step * multiplier * direction)
+        session.values[spec.name] = spec.formatNumber(next)
+      }
+      ParamType.PLAYER,
+      ParamType.ENUM,
+      ParamType.MATERIAL,
+      ParamType.TEXT -> {
+        val options = spec.options(player)
+        if (options.isEmpty()) return
+        val currentIndex = options.indexOf(current).takeIf { it >= 0 } ?: 0
+        val nextIndex = Math.floorMod(currentIndex + direction, options.size)
+        session.values[spec.name] = options[nextIndex]
+      }
+    }
+  }
+
+  fun executeCommand(player: Player, rawCommand: String, mode: String) {
+    if (!player.isOp) {
+      player.sendMessage(c("&cこのコマンドはOP限定です。"))
+      return
+    }
+    val command = normalizeCommand(rawCommand)
+    if (command.isBlank()) return
+    when (mode.lowercase(Locale.ROOT)) {
+      "console" -> Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command)
+      "op" -> {
+        val wasOp = player.isOp
+        try {
+          player.isOp = true
+          player.performCommand(command)
+        } finally {
+          player.isOp = wasOp
+        }
+      }
+      else -> player.performCommand(command)
+    }
+  }
+
+  private fun normalizeCommand(rawCommand: String): String =
+      normalizeTypedInput(rawCommand).let { if (it.startsWith("/")) it.removePrefix("/") else it }
+
+  private fun normalizeTypedInput(raw: String): String {
+    val text = raw.trim()
+    val unescaped = if (text.startsWith("\\/")) text.removePrefix("\\") else text
+    if (unescaped.length >= 2) {
+      val first = unescaped.first()
+      val last = unescaped.last()
+      if ((first == '"' && last == '"') || (first == '\'' && last == '\'')) {
+        return unescaped.substring(1, unescaped.length - 1)
+      }
+    }
+    return unescaped
+  }
+
+  private fun expandCommand(player: Player, session: ParamCommandSession): String {
+    var result = plugin.menuEngine.applyPlaceholders(player, session.template)
+    session.values.forEach { (key, value) -> result = result.replace("{$key}", value) }
+    return result
+  }
+
+  private fun buildSpecs(action: MenuAction, template: String): List<ParamSpec> {
+    val nested = action.params["params"] as? Map<*, *>
+    return placeholderPattern
+        .findAll(template)
+        .map { it.groupValues[1] }
+        .distinct()
+        .map { name ->
+          val nestedSpec = nested?.get(name) as? Map<*, *>
+          ParamSpec(
+              name = name,
+              type = paramType(stringValue(action, nestedSpec, name, "type") ?: inferType(name)),
+              min = doubleValue(action, nestedSpec, name, "min"),
+              max = doubleValue(action, nestedSpec, name, "max"),
+              step = doubleValue(action, nestedSpec, name, "step") ?: 1.0,
+              defaultRaw = stringValue(action, nestedSpec, name, "default"),
+              enumOptions = listValue(action, nestedSpec, name, "options"))
+        }
+        .toList()
+  }
+
+  private fun stringValue(
+      action: MenuAction,
+      nestedSpec: Map<*, *>?,
+      name: String,
+      key: String
+  ): String? =
+      nestedSpec?.get(key)?.toString()
+          ?: action.params["param.$name.$key"]?.toString()
+          ?: action.params["${name}_$key"]?.toString()
+
+  private fun doubleValue(
+      action: MenuAction,
+      nestedSpec: Map<*, *>?,
+      name: String,
+      key: String
+  ): Double? = stringValue(action, nestedSpec, name, key)?.toDoubleOrNull()
+
+  private fun listValue(
+      action: MenuAction,
+      nestedSpec: Map<*, *>?,
+      name: String,
+      key: String
+  ): List<String> {
+    val raw = nestedSpec?.get(key) ?: action.params["param.$name.$key"] ?: return emptyList()
+    return when (raw) {
+      is List<*> -> raw.mapNotNull { it?.toString() }
+      else -> raw.toString().split(',').map { it.trim() }.filter { it.isNotEmpty() }
+    }
+  }
+
+  private fun inferType(name: String): String {
+    val lower = name.lowercase(Locale.ROOT)
+    return when {
+      lower in setOf("player", "target", "user") -> "player"
+      lower.contains("block") || lower.contains("material") || lower.contains("item") -> "material"
+      lower.contains("radius") || lower.contains("scale") || lower.contains("speed") -> "float"
+      else -> "int"
+    }
+  }
+
+  private fun paramType(raw: String): ParamType =
+      runCatching { ParamType.valueOf(raw.uppercase(Locale.ROOT)) }.getOrDefault(ParamType.TEXT)
+
+  private fun executionMode(action: MenuAction): String =
+      action.getString("execution", action.getString("mode", "player"))
+
+  private fun valueSlots(): List<Int> = (10..16).toList() + (19..25).toList() + (28..34).toList()
+
+  private fun paramItem(spec: ParamSpec, value: String): ItemStack {
+    val material =
+        when (spec.type) {
+          ParamType.INT -> Material.REPEATER
+          ParamType.FLOAT -> Material.COMPARATOR
+          ParamType.MATERIAL -> Material.STONE
+          ParamType.PLAYER -> Material.PLAYER_HEAD
+          ParamType.ENUM -> Material.BOOK
+          ParamType.TEXT -> Material.NAME_TAG
+        }
+    return item(
+        material,
+        "&e${spec.name}",
+        "&7型: &f${spec.type.name.lowercase(Locale.ROOT)}",
+        "&7現在: &a$value",
+        "&7左クリック: + / 次へ",
+        "&7右クリック: - / 前へ",
+        "&7Shift・中クリック: 手入力")
+  }
+
+  private fun fill(inv: Inventory, mat: Material) {
+    val glass = item(mat, " ")
+    for (i in 0 until inv.size) inv.setItem(i, glass)
+  }
+
+  private fun item(mat: Material, name: String, vararg lore: String): ItemStack {
+    val item = ItemStack(mat)
+    val meta = item.itemMeta ?: return item
+    meta.displayName(comp(name))
+    if (lore.isNotEmpty()) meta.lore(lore.map { comp(it) })
+    meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES)
+    item.itemMeta = meta
+    return item
+  }
+
+  private data class ParamCommandSession(
+      val template: String,
+      val specs: List<ParamSpec>,
+      val values: MutableMap<String, String>,
+      val action: MenuAction
+  )
+
+  private data class PendingTextInput(val session: ParamCommandSession, val spec: ParamSpec)
+
+  private class ParamCommandHolder(val session: ParamCommandSession) : InventoryHolder {
+    override fun getInventory(): Inventory = Bukkit.createInventory(this, 54)
+  }
+
+  private enum class ParamType {
+    INT,
+    FLOAT,
+    TEXT,
+    MATERIAL,
+    PLAYER,
+    ENUM
+  }
+
+  private data class ParamSpec(
+      val name: String,
+      val type: ParamType,
+      val min: Double?,
+      val max: Double?,
+      val step: Double,
+      val defaultRaw: String?,
+      val enumOptions: List<String>
+  ) {
+    val defaultNumber: Double =
+        defaultRaw?.toDoubleOrNull() ?: if (type == ParamType.FLOAT) 1.0 else 1.0
+
+    fun defaultValue(player: Player): String =
+        defaultRaw
+            ?: when (type) {
+              ParamType.INT -> "1"
+              ParamType.FLOAT -> "1.0"
+              ParamType.MATERIAL -> "stone"
+              ParamType.PLAYER -> player.name
+              ParamType.ENUM -> enumOptions.firstOrNull() ?: ""
+              ParamType.TEXT -> ""
+            }
+
+    fun normalizeInput(raw: String): String? =
+        when (type) {
+          ParamType.INT -> raw.toIntOrNull()?.let { formatNumber(clamp(it.toDouble())) }
+          ParamType.FLOAT -> raw.toDoubleOrNull()?.let { formatNumber(clamp(it)) }
+          else -> raw.takeIf { it.isNotBlank() }
+        }
+
+    fun options(player: Player): List<String> =
+        when (type) {
+          ParamType.PLAYER -> Bukkit.getOnlinePlayers().map { it.name }.sorted()
+          ParamType.MATERIAL ->
+              listOf("stone", "oak_planks", "glass", "air", "dirt", "grass_block", "water")
+          ParamType.ENUM -> enumOptions
+          else -> enumOptions
+        }
+
+    fun clamp(value: Double): Double {
+      var result = value
+      if (min != null) result = result.coerceAtLeast(min)
+      if (max != null) result = result.coerceAtMost(max)
+      return result
+    }
+
+    fun formatNumber(value: Double): String =
+        when (type) {
+          ParamType.INT -> value.roundToInt().toString()
+          else -> "%.4f".format(Locale.US, value).trimEnd('0').trimEnd('.').ifEmpty { "0" }
+        }
+  }
+}

--- a/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/engine/PointShopEngine.kt
+++ b/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/engine/PointShopEngine.kt
@@ -59,6 +59,9 @@ class PointShopEngine(private val plugin: OyasaiMenu) : Listener {
       state: PlayerPointShopState
   ): Inventory {
     val tokens = TokenCurrencyManager.getTokens(player)
+    val balanceText =
+        if (EconomyManager.isAvailable) EconomyManager.format(EconomyManager.getBalance(player))
+        else "---"
     val inv =
         Bukkit.createInventory(
             null,
@@ -66,14 +69,19 @@ class PointShopEngine(private val plugin: OyasaiMenu) : Listener {
             comp("${c(category.displayName)} &8| &f${state.page+1}&8/&f${category.pageCount}"))
     category.getPage(state.page).forEachIndexed { i, item ->
       if (!item.icon.isAir) {
-        inv.setItem(i, buildItemStack(player, item, tokens))
+        inv.setItem(i, buildItemStack(player, item, tokens, balanceText))
       }
     }
-    buildBottomBar(inv, player, category, state, tokens)
+    buildBottomBar(inv, category, state, tokens, balanceText)
     return inv
   }
 
-  private fun buildItemStack(player: Player, item: PointShopItem, tokens: Long): ItemStack {
+  private fun buildItemStack(
+      player: Player,
+      item: PointShopItem,
+      tokens: Long,
+      balanceText: String
+  ): ItemStack {
     val stack: ItemStack =
         when {
           item.customTexture != null -> CustomHead.get(item.customTexture)
@@ -81,7 +89,6 @@ class PointShopEngine(private val plugin: OyasaiMenu) : Listener {
         }
     val meta = stack.itemMeta ?: return stack
     if (item.name.isNotEmpty()) meta.displayName(comp(item.name.replace("%player%", player.name)))
-    val balance = if (EconomyManager.isAvailable) EconomyManager.getBalance(player) else 0.0
     val lore =
         item.lore
             .map { line ->
@@ -90,10 +97,7 @@ class PointShopEngine(private val plugin: OyasaiMenu) : Listener {
                       .replace("%player%", player.name)
                       .replace("%tokens%", TokenCurrencyManager.format(tokens))
                       .replace("%price%", TokenCurrencyManager.format(item.cost))
-                      .replace(
-                          "%balance%",
-                          if (EconomyManager.isAvailable) EconomyManager.format(balance)
-                          else "---"))
+                      .replace("%balance%", balanceText))
             }
             .toMutableList()
     lore += comp("")
@@ -112,10 +116,10 @@ class PointShopEngine(private val plugin: OyasaiMenu) : Listener {
 
   private fun buildBottomBar(
       inv: Inventory,
-      player: Player,
       category: PointShopCategory,
       state: PlayerPointShopState,
-      tokens: Long
+      tokens: Long,
+      balanceText: String
   ) {
     val glass = makeItem(Material.BLACK_STAINED_GLASS_PANE, " ")
     listOf(46, 47, 51, 52).forEach { inv.setItem(it, glass) }
@@ -138,15 +142,12 @@ class PointShopEngine(private val plugin: OyasaiMenu) : Listener {
         makeItem(
             if (hasNext) Material.ARROW else Material.BLACK_STAINED_GLASS_PANE,
             if (hasNext) "&e次のページ →" else "&8次のページなし"))
-    val balStr =
-        if (EconomyManager.isAvailable) EconomyManager.format(EconomyManager.getBalance(player))
-        else "---"
     inv.setItem(
         53,
         makeItem(
             Material.NETHER_STAR,
             "&f所持ポイント: &3${TokenCurrencyManager.format(tokens)}&fP",
-            listOf("&7所持金: &6$balStr", "", "&eクリックで残高を更新")))
+            listOf("&7所持金: &6$balanceText", "", "&eクリックで残高を更新")))
   }
 
   @EventHandler
@@ -169,7 +170,10 @@ class PointShopEngine(private val plugin: OyasaiMenu) : Listener {
       50 -> changePage(player, state, category, state.page + 1)
       53 -> {
         val newTokens = TokenCurrencyManager.getTokens(player)
-        buildBottomBar(player.openInventory.topInventory, player, category, state, newTokens)
+        val balanceText =
+            if (EconomyManager.isAvailable) EconomyManager.format(EconomyManager.getBalance(player))
+            else "---"
+        buildBottomBar(player.openInventory.topInventory, category, state, newTokens, balanceText)
         player.playSound(player.location, org.bukkit.Sound.UI_BUTTON_CLICK, 0.5f, 1f)
       }
       in 0..44 -> {
@@ -236,11 +240,14 @@ class PointShopEngine(private val plugin: OyasaiMenu) : Listener {
             cmd.replace("%player%", player.name).replace("%price%", item.cost.toString()))
       }
       val newTokens = TokenCurrencyManager.getTokens(player)
+      val balanceText =
+          if (EconomyManager.isAvailable) EconomyManager.format(EconomyManager.getBalance(player))
+          else "---"
       val inv = player.openInventory.topInventory
       category.getPage(state.page).forEachIndexed { i, it ->
-        if (!it.icon.isAir) inv.setItem(i, buildItemStack(player, it, newTokens))
+        if (!it.icon.isAir) inv.setItem(i, buildItemStack(player, it, newTokens, balanceText))
       }
-      buildBottomBar(inv, player, category, state, newTokens)
+      buildBottomBar(inv, category, state, newTokens, balanceText)
     }
   }
 

--- a/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/engine/PopupMenuEngine.kt
+++ b/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/engine/PopupMenuEngine.kt
@@ -395,6 +395,7 @@ class PopupMenuEngine(private val plugin: OyasaiMenu) : Listener {
           player.sendMessage(msg)
         }
         PopupActionType.OPEN_POPUP -> open(player, action.value)
+        PopupActionType.OPEN_SPECIAL -> plugin.specialMenuEngine.open(player, action.value)
         PopupActionType.OPEN_SHOP -> {
           val cat = action.value
           if (cat.isEmpty()) open(player, "shopindex") else plugin.shopEngine.openShop(player, cat)

--- a/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/engine/SpecialMenuEngine.kt
+++ b/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/engine/SpecialMenuEngine.kt
@@ -1,0 +1,168 @@
+package com.github.sahyuya.oyasaiMenu.engine
+
+import com.github.sahyuya.oyasaiMenu.OyasaiMenu
+import com.github.sahyuya.oyasaiMenu.model.MenuAction
+import com.github.sahyuya.oyasaiMenu.util.GuiUtil.c
+import com.github.sahyuya.oyasaiMenu.util.GuiUtil.comp
+import org.bukkit.Bukkit
+import org.bukkit.Material
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.inventory.InventoryClickEvent
+import org.bukkit.inventory.Inventory
+import org.bukkit.inventory.InventoryHolder
+import org.bukkit.inventory.ItemFlag
+import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.meta.SkullMeta
+
+class SpecialMenuEngine(private val plugin: OyasaiMenu) : Listener {
+
+  fun open(player: Player, target: String, action: MenuAction? = null) {
+    if (!player.isOp) {
+      player.sendMessage(c("&c特殊メニューはOP限定です。"))
+      return
+    }
+    when (target.lowercase()) {
+      "online_players",
+      "online-players",
+      "players" -> openOnlinePlayers(player, 0)
+      "confirm" -> {
+        val command = action?.let { it.getString("command", it.getString("confirm_command")) } ?: ""
+        if (command.isBlank()) {
+          player.sendMessage(c("&cconfirm 特殊メニューには command が必要です。"))
+          return
+        }
+        openConfirmCommand(player, command, action?.getString("mode", "player") ?: "player")
+      }
+      else -> player.sendMessage(c("&c未知の特殊メニューです: $target"))
+    }
+  }
+
+  fun openOnlinePlayers(player: Player, page: Int) {
+    if (!player.isOp) {
+      player.sendMessage(c("&c特殊メニューはOP限定です。"))
+      return
+    }
+    val players = Bukkit.getOnlinePlayers().sortedBy { it.name.lowercase() }
+    val maxPage = ((players.size - 1).coerceAtLeast(0)) / 45
+    val safePage = page.coerceIn(0, maxPage)
+    val inv =
+        Bukkit.createInventory(
+            OnlinePlayersHolder(safePage), 54, comp("&8オンラインプレイヤー (${players.size})"))
+    fill(inv, Material.GRAY_STAINED_GLASS_PANE)
+    players.drop(safePage * 45).take(45).forEachIndexed { index, target ->
+      inv.setItem(index, playerHead(target))
+    }
+    inv.setItem(45, item(Material.ARROW, "&e前のページ", "&7現在: ${safePage + 1} / ${maxPage + 1}"))
+    inv.setItem(49, item(Material.ENDER_CHEST, "&aメインメニュー", "&7root を開きます"))
+    inv.setItem(53, item(Material.ARROW, "&e次のページ", "&7現在: ${safePage + 1} / ${maxPage + 1}"))
+    player.openInventory(inv)
+  }
+
+  fun openConfirmCommand(player: Player, command: String, mode: String = "player") {
+    if (!player.isOp) {
+      player.sendMessage(c("&c確認メニューはOP限定です。"))
+      return
+    }
+    val inv = Bukkit.createInventory(ConfirmCommandHolder(command, mode), 54, comp("&8コマンド実行確認"))
+    fill(inv, Material.GRAY_STAINED_GLASS_PANE)
+    inv.setItem(
+        13, item(Material.COMMAND_BLOCK, "&f実行予定", "&7mode: &f$mode", "&7command: &e$command"))
+    inv.setItem(20, item(Material.LIME_CONCRETE, "&a実行する", "&7このコマンドを実行します"))
+    inv.setItem(24, item(Material.RED_CONCRETE, "&cキャンセル", "&7何もせず閉じます"))
+    player.openInventory(inv)
+  }
+
+  @EventHandler
+  fun onInventoryClick(event: InventoryClickEvent) {
+    val player = event.whoClicked as? Player ?: return
+    when (val holder = event.inventory.holder) {
+      is OnlinePlayersHolder -> handleOnlinePlayersClick(event, player, holder)
+      is ConfirmCommandHolder -> handleConfirmClick(event, player, holder)
+      else -> return
+    }
+  }
+
+  private fun handleOnlinePlayersClick(
+      event: InventoryClickEvent,
+      player: Player,
+      holder: OnlinePlayersHolder
+  ) {
+    event.isCancelled = true
+    if (event.clickedInventory != event.inventory) return
+    if (!player.isOp) {
+      player.closeInventory()
+      player.sendMessage(c("&c特殊メニューはOP限定です。"))
+      return
+    }
+    when (event.rawSlot) {
+      45 -> openOnlinePlayers(player, holder.page - 1)
+      49 -> plugin.menuEngine.openMenu(player, "root")
+      53 -> openOnlinePlayers(player, holder.page + 1)
+      in 0..44 -> {
+        val targetId =
+            event.currentItem?.itemMeta?.let { meta ->
+              (meta as? SkullMeta)?.owningPlayer?.uniqueId
+            } ?: return
+        val target = Bukkit.getPlayer(targetId) ?: return
+        player.closeInventory()
+        player.performCommand("tp ${target.name}")
+      }
+    }
+  }
+
+  private fun handleConfirmClick(
+      event: InventoryClickEvent,
+      player: Player,
+      holder: ConfirmCommandHolder
+  ) {
+    event.isCancelled = true
+    if (event.clickedInventory != event.inventory) return
+    if (!player.isOp) {
+      player.closeInventory()
+      player.sendMessage(c("&c確認メニューはOP限定です。"))
+      return
+    }
+    when (event.rawSlot) {
+      20 -> {
+        player.closeInventory()
+        plugin.parameterCommandEngine.executeCommand(player, holder.command, holder.mode)
+      }
+      24 -> player.closeInventory()
+    }
+  }
+
+  private fun playerHead(target: Player): ItemStack {
+    val item = ItemStack(Material.PLAYER_HEAD)
+    val meta = item.itemMeta as? SkullMeta ?: return item
+    meta.owningPlayer = target
+    meta.displayName(comp("&a${target.name}"))
+    meta.lore(listOf(comp("&7左クリックで /tp ${target.name}")))
+    item.itemMeta = meta
+    return item
+  }
+
+  private fun fill(inv: Inventory, mat: Material) {
+    val glass = item(mat, " ")
+    for (i in 0 until inv.size) inv.setItem(i, glass)
+  }
+
+  private fun item(mat: Material, name: String, vararg lore: String): ItemStack {
+    val item = ItemStack(mat)
+    val meta = item.itemMeta ?: return item
+    meta.displayName(comp(name))
+    if (lore.isNotEmpty()) meta.lore(lore.map { comp(it) })
+    meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES)
+    item.itemMeta = meta
+    return item
+  }
+
+  private class OnlinePlayersHolder(val page: Int) : InventoryHolder {
+    override fun getInventory(): Inventory = Bukkit.createInventory(this, 54)
+  }
+
+  private class ConfirmCommandHolder(val command: String, val mode: String) : InventoryHolder {
+    override fun getInventory(): Inventory = Bukkit.createInventory(this, 54)
+  }
+}

--- a/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/guimaker/EditableSurfaceAdapter.kt
+++ b/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/guimaker/EditableSurfaceAdapter.kt
@@ -1,0 +1,71 @@
+package com.github.sahyuya.oyasaiMenu.guimaker
+
+import com.github.sahyuya.oyasaiMenu.OyasaiMenu
+
+data class EditCapabilities(
+    val freeSlotEditing: Boolean = true,
+    val reservedSlots: Set<Int> = emptySet(),
+    val structuredSettings: Boolean = false,
+    val templateLibrary: Boolean = false
+)
+
+interface EditableSurfaceAdapter {
+  val type: GuiEditableSurface
+  val label: String
+  val capabilities: EditCapabilities
+
+  fun listIds(plugin: OyasaiMenu): List<String>
+
+  fun newSession(plugin: OyasaiMenu, id: String): GuiEditorSession
+
+  fun load(plugin: OyasaiMenu, id: String): GuiEditorSession?
+
+  fun save(plugin: OyasaiMenu, session: GuiEditorSession): Result<String>
+
+  fun hasDraft(plugin: OyasaiMenu, id: String): Boolean
+}
+
+object NormalMenuAdapter : EditableSurfaceAdapter {
+  override val type = GuiEditableSurface.NORMAL
+  override val label = "通常GUI"
+  override val capabilities = EditCapabilities()
+
+  override fun listIds(plugin: OyasaiMenu): List<String> = GuiMakerExporter.listMenuIds(plugin)
+
+  override fun newSession(plugin: OyasaiMenu, id: String): GuiEditorSession = GuiEditorSession(id)
+
+  override fun load(plugin: OyasaiMenu, id: String): GuiEditorSession? {
+    val session = GuiEditorSession(id)
+    return if (GuiMakerExporter.loadIntoSession(plugin, session)) session else null
+  }
+
+  override fun save(plugin: OyasaiMenu, session: GuiEditorSession): Result<String> =
+      GuiMakerExporter.commit(plugin, session)
+
+  override fun hasDraft(plugin: OyasaiMenu, id: String): Boolean =
+      GuiMakerExporter.hasDraft(plugin, id)
+}
+
+object PopupMenuAdapter : EditableSurfaceAdapter {
+  override val type = GuiEditableSurface.POPUP
+  override val label = "Popupメニュー"
+  override val capabilities =
+      EditCapabilities(
+          freeSlotEditing = true, reservedSlots = (45..53).toSet(), structuredSettings = true)
+
+  override fun listIds(plugin: OyasaiMenu): List<String> = GuiMakerExporter.listPopupIds(plugin)
+
+  override fun newSession(plugin: OyasaiMenu, id: String): GuiEditorSession =
+      GuiMakerExporter.newPopupSession(id)
+
+  override fun load(plugin: OyasaiMenu, id: String): GuiEditorSession? {
+    val session = GuiMakerExporter.newPopupSession(id)
+    return if (GuiMakerExporter.loadPopupIntoSession(plugin, session)) session else null
+  }
+
+  override fun save(plugin: OyasaiMenu, session: GuiEditorSession): Result<String> =
+      GuiMakerExporter.commit(plugin, session)
+
+  override fun hasDraft(plugin: OyasaiMenu, id: String): Boolean =
+      GuiMakerExporter.hasPopupDraft(plugin, id)
+}

--- a/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/guimaker/GuiActionCatalog.kt
+++ b/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/guimaker/GuiActionCatalog.kt
@@ -7,7 +7,9 @@ object GuiActionCatalog {
       listOf(
           "OPEN_MENU",
           "OPEN_POPUP",
+          "OPEN_SPECIAL",
           "PLAYER_CMD",
+          "PARAM_COMMAND",
           "CONSOLE_CMD",
           "OP_PLAYER_CMD",
           "MESSAGE",
@@ -21,8 +23,10 @@ object GuiActionCatalog {
   fun params(type: String, value: String, soundVolume: String? = null): Map<String, String> =
       when (type.uppercase()) {
         "OPEN_MENU",
-        "OPEN_POPUP" -> mapOf("target" to value)
+        "OPEN_POPUP",
+        "OPEN_SPECIAL" -> mapOf("target" to value)
         "PLAYER_CMD",
+        "PARAM_COMMAND",
         "CONSOLE_CMD",
         "OP_PLAYER_CMD",
         "SUGGEST_COMMAND" -> mapOf("command" to value)
@@ -43,7 +47,9 @@ object GuiActionCatalog {
       when (type) {
         "OPEN_MENU" -> Material.ENDER_CHEST
         "OPEN_POPUP" -> Material.CHORUS_FRUIT
+        "OPEN_SPECIAL" -> Material.ENDER_EYE
         "PLAYER_CMD",
+        "PARAM_COMMAND",
         "SUGGEST_COMMAND" -> Material.STICK
         "CONSOLE_CMD" -> Material.REDSTONE
         "OP_PLAYER_CMD" -> Material.NETHER_STAR
@@ -59,8 +65,10 @@ object GuiActionCatalog {
   fun paramLabel(type: String): String =
       when (type) {
         "OPEN_MENU",
-        "OPEN_POPUP" -> "target"
+        "OPEN_POPUP",
+        "OPEN_SPECIAL" -> "target"
         "PLAYER_CMD",
+        "PARAM_COMMAND",
         "CONSOLE_CMD",
         "OP_PLAYER_CMD",
         "SUGGEST_COMMAND" -> "command"
@@ -76,6 +84,8 @@ object GuiActionCatalog {
   fun paramPrompt(type: String): String =
       when (type) {
         "PLAYER_CMD" -> "プレイヤーとして実行するコマンドを入力 (/ 不要, %player% 使用可):"
+        "PARAM_COMMAND" -> "可変コマンドを入力 ({amount} 使用可。//stack はそのまま、または \"//stack {amount}\" でも可):"
+        "OPEN_SPECIAL" -> "特殊メニューIDを入力 (online_players / confirm):"
         "CONSOLE_CMD" -> "コンソールとして実行するコマンドを入力 (/ 不要, %player% 使用可):"
         "OP_PLAYER_CMD" -> "OP権限で実行するコマンドを入力 (/ 不要):"
         "SUGGEST_COMMAND" -> "コマンド候補を入力 (/ 不要):"
@@ -90,6 +100,8 @@ object GuiActionCatalog {
     val type =
         when (funcLabel) {
           "プレイヤーコマンド" -> "PLAYER_CMD"
+          "可変コマンド" -> "PARAM_COMMAND"
+          "特殊メニュー" -> "OPEN_SPECIAL"
           "コンソールコマンド" -> "CONSOLE_CMD"
           "OPコマンド" -> "OP_PLAYER_CMD"
           "コマンドを提案",

--- a/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/guimaker/GuiActionCatalog.kt
+++ b/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/guimaker/GuiActionCatalog.kt
@@ -8,6 +8,10 @@ object GuiActionCatalog {
           "OPEN_MENU",
           "OPEN_POPUP",
           "OPEN_SPECIAL",
+          "OPEN_SHOP",
+          "OPEN_POINT_SHOP",
+          "OPEN_SELL",
+          "OPEN_MACRO",
           "PLAYER_CMD",
           "PARAM_COMMAND",
           "CONSOLE_CMD",
@@ -25,6 +29,10 @@ object GuiActionCatalog {
         "OPEN_MENU",
         "OPEN_POPUP",
         "OPEN_SPECIAL" -> mapOf("target" to value)
+        "OPEN_SHOP",
+        "OPEN_POINT_SHOP" -> mapOf("category" to value)
+        "OPEN_SELL",
+        "OPEN_MACRO" -> emptyMap()
         "PLAYER_CMD",
         "PARAM_COMMAND",
         "CONSOLE_CMD",
@@ -48,6 +56,10 @@ object GuiActionCatalog {
         "OPEN_MENU" -> Material.ENDER_CHEST
         "OPEN_POPUP" -> Material.CHORUS_FRUIT
         "OPEN_SPECIAL" -> Material.ENDER_EYE
+        "OPEN_SHOP" -> Material.CHEST
+        "OPEN_POINT_SHOP" -> Material.NETHER_STAR
+        "OPEN_SELL" -> Material.GOLD_INGOT
+        "OPEN_MACRO" -> Material.COMMAND_BLOCK
         "PLAYER_CMD",
         "PARAM_COMMAND",
         "SUGGEST_COMMAND" -> Material.STICK
@@ -67,6 +79,10 @@ object GuiActionCatalog {
         "OPEN_MENU",
         "OPEN_POPUP",
         "OPEN_SPECIAL" -> "target"
+        "OPEN_SHOP",
+        "OPEN_POINT_SHOP" -> "category"
+        "OPEN_SELL",
+        "OPEN_MACRO" -> "(なし)"
         "PLAYER_CMD",
         "PARAM_COMMAND",
         "CONSOLE_CMD",
@@ -86,6 +102,8 @@ object GuiActionCatalog {
         "PLAYER_CMD" -> "プレイヤーとして実行するコマンドを入力 (/ 不要, %player% 使用可):"
         "PARAM_COMMAND" -> "可変コマンドを入力 ({amount} 使用可。//stack はそのまま、または \"//stack {amount}\" でも可):"
         "OPEN_SPECIAL" -> "特殊メニューIDを入力 (online_players / confirm):"
+        "OPEN_SHOP" -> "ショップカテゴリIDを入力:"
+        "OPEN_POINT_SHOP" -> "ポイントショップカテゴリIDを入力:"
         "CONSOLE_CMD" -> "コンソールとして実行するコマンドを入力 (/ 不要, %player% 使用可):"
         "OP_PLAYER_CMD" -> "OP権限で実行するコマンドを入力 (/ 不要):"
         "SUGGEST_COMMAND" -> "コマンド候補を入力 (/ 不要):"

--- a/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/guimaker/GuiEditorEngine.kt
+++ b/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/guimaker/GuiEditorEngine.kt
@@ -1,6 +1,7 @@
 package com.github.sahyuya.oyasaiMenu.guimaker
 
 import com.github.sahyuya.oyasaiMenu.OyasaiMenu
+import com.github.sahyuya.oyasaiMenu.engine.NavBar
 import com.github.sahyuya.oyasaiMenu.model.ActionType
 import com.github.sahyuya.oyasaiMenu.model.MenuAction
 import com.github.sahyuya.oyasaiMenu.util.ItemVisuals
@@ -21,6 +22,7 @@ import org.bukkit.event.inventory.ClickType
 import org.bukkit.event.inventory.InventoryAction
 import org.bukkit.event.inventory.InventoryClickEvent
 import org.bukkit.event.inventory.InventoryCloseEvent
+import org.bukkit.event.inventory.InventoryDragEvent
 import org.bukkit.event.player.AsyncPlayerChatEvent
 import org.bukkit.event.player.PlayerCommandPreprocessEvent
 import org.bukkit.inventory.Inventory
@@ -38,6 +40,7 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
   private val KEY_PERM by lazy { NamespacedKey(plugin, "gm_perm") }
   private val KEY_ACTIONS by lazy { NamespacedKey(plugin, "gm_actions") }
   private val KEY_ENCHANTED by lazy { NamespacedKey(plugin, "gm_enchanted") }
+  private val KEY_EXTRA by lazy { NamespacedKey(plugin, "gm_extra") }
   private val KEY_FUNC by lazy { NamespacedKey(plugin, "gm_func") }
   private val KEY_SCREEN by lazy { NamespacedKey(plugin, "gm_screen") }
   private val KEY_SKIN_ITEM by lazy { NamespacedKey(plugin, "gm_skin_item") }
@@ -97,6 +100,114 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
 
   fun uiScreenNames(): List<String> = UI_SCREEN_DEFS.keys.toList()
 
+  fun openHub(player: Player) {
+    val inv = Bukkit.createInventory(HubHolder(), 54, comp("&8GuiMaker 編集ハブ"))
+    fillMain(inv, Material.GRAY_STAINED_GLASS_PANE)
+    inv.setItem(
+        10,
+        makeItem(Material.ENDER_CHEST, "&a通常GUI", "&7menus/*.yml を編集します", "&7自由配置・アクション・権限・lore"))
+    inv.setItem(
+        12,
+        makeItem(
+            Material.CHORUS_FRUIT,
+            "&dPopupメニュー",
+            "&7menus/popup/*.yml を専用形式で編集します",
+            "&745-53 はナビバー予約としてロックします"))
+    inv.setItem(
+        14,
+        makeItem(Material.ENDER_EYE, "&b特殊メニュー", "&7オンラインプレイヤー・確認・可変コマンドなど", "&7コード駆動メニューの入口です"))
+    inv.setItem(
+        16,
+        makeItem(
+            Material.ITEM_FRAME,
+            "&eGUI Maker UI",
+            "&7gui-maker-ui-screens.yml をGUIから編集します",
+            "&7現在の /guimaker ui edit の入口です"))
+    inv.setItem(
+        31,
+        makeItem(
+            Material.NETHER_STAR,
+            "&6テンプレート / 公式ブロック",
+            "&7通常GUI編集中のテンプレート管理を開きます",
+            "&7未編集中の場合は root の編集から入ります"))
+    inv.setItem(49, makeItem(Material.BOOK, "&fヘルプ", "&7コマンド一覧をチャットに表示します"))
+    inv.setItem(53, makeItem(Material.BARRIER, "&c閉じる"))
+    applyUiSkin(inv, "hub")
+    player.openInventory(inv)
+  }
+
+  fun openNormalMenuList(player: Player, page: Int = 0) {
+    val ids = NormalMenuAdapter.listIds(plugin)
+    openSurfaceList(
+        player,
+        SurfaceListHolder(GuiEditableSurface.NORMAL, page),
+        "&8通常GUI編集",
+        Material.ENDER_CHEST,
+        ids,
+        page)
+  }
+
+  fun openPopupMenuList(player: Player, page: Int = 0) {
+    val ids = PopupMenuAdapter.listIds(plugin)
+    openSurfaceList(
+        player,
+        SurfaceListHolder(GuiEditableSurface.POPUP, page),
+        "&8Popup編集",
+        Material.CHORUS_FRUIT,
+        ids,
+        page)
+  }
+
+  fun openUiScreenList(player: Player, page: Int = 0) {
+    val screens = uiScreenNames()
+    val inv = Bukkit.createInventory(UiScreenListHolder(page), 54, comp("&8GUI Maker UI編集"))
+    fillMain(inv, Material.YELLOW_STAINED_GLASS_PANE)
+    inv.setItem(4, makeItem(Material.ITEM_FRAME, "&eGUI Maker UI", "&7編集画面を選択してください"))
+    val grid = listGridSlots()
+    val maxPage = ((screens.size - 1).coerceAtLeast(0)) / grid.size
+    val safePage = page.coerceIn(0, maxPage)
+    screens.drop(safePage * grid.size).take(grid.size).forEachIndexed { index, screen ->
+      inv.setItem(grid[index], makeItem(Material.ITEM_FRAME, "&e$screen", "&7クリックでこの画面のUIを編集"))
+    }
+    inv.setItem(45, makeItem(Material.ARROW, "&f編集ハブへ戻る"))
+    inv.setItem(48, makeItem(Material.ARROW, "&e前のページ", "&7${safePage + 1}/${maxPage + 1}"))
+    inv.setItem(50, makeItem(Material.ARROW, "&e次のページ", "&7${safePage + 1}/${maxPage + 1}"))
+    applyUiSkin(inv, "ui_screen_list")
+    player.openInventory(inv)
+  }
+
+  fun openSpecialSurfaceHub(player: Player) {
+    val inv = Bukkit.createInventory(SpecialSurfaceHubHolder(), 54, comp("&8特殊メニュー"))
+    fillMain(inv, Material.LIGHT_BLUE_STAINED_GLASS_PANE)
+    inv.setItem(
+        11,
+        makeItem(Material.PLAYER_HEAD, "&bオンラインプレイヤー一覧", "&7OP限定のコード駆動メニュー", "&7クリックでプレビューを開きます"))
+    inv.setItem(
+        13, makeItem(Material.LIME_CONCRETE, "&a確認ボタンメニュー", "&7コマンド実行前の確認画面", "&7クリックでサンプル確認を開きます"))
+    inv.setItem(
+        15,
+        makeItem(
+            Material.REPEATER,
+            "&e可変コマンドメニュー",
+            "&7{amount} などの入力枠を持つコマンド",
+            "&7通常GUI/Popupのアクションから配置します"))
+    inv.setItem(45, makeItem(Material.ARROW, "&f編集ハブへ戻る"))
+    inv.setItem(31, makeItem(Material.ENDER_CHEST, "&a通常GUIへ配置", "&7特殊メニューを呼ぶボタンを作る入口"))
+    applyUiSkin(inv, "special_surface")
+    player.openInventory(inv)
+  }
+
+  fun openTemplateLibrary(player: Player) {
+    val session =
+        getSession(player)
+            ?: NormalMenuAdapter.load(plugin, "root")?.also { sessions[player.uniqueId] = it }
+            ?: run {
+              msg(player, "&e[GuiMaker] &cテンプレート管理は通常GUI編集中に開いてください。")
+              return
+            }
+    openTemplateHub(player, session)
+  }
+
   private fun getFavorites(playerId: UUID): MutableList<GuiActionDef> =
       playerFavorites.getOrPut(playerId) { loadFavoritesFromDisk(playerId) }
 
@@ -134,6 +245,59 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
     }
   }
 
+  private fun openSurfaceList(
+      player: Player,
+      holder: SurfaceListHolder,
+      title: String,
+      material: Material,
+      ids: List<String>,
+      page: Int
+  ) {
+    val inv = Bukkit.createInventory(holder, 54, comp(title))
+    fillMain(
+        inv,
+        if (holder.surface == GuiEditableSurface.POPUP) Material.PURPLE_STAINED_GLASS_PANE
+        else Material.LIME_STAINED_GLASS_PANE)
+    val grid = listGridSlots()
+    val maxPage = ((ids.size - 1).coerceAtLeast(0)) / grid.size
+    val safePage = page.coerceIn(0, maxPage)
+    inv.setItem(
+        4,
+        makeItem(
+            material,
+            if (holder.surface == GuiEditableSurface.POPUP) "&dPopupメニュー" else "&a通常GUI",
+            "&7編集対象を選択してください",
+            "&7${ids.size} 件"))
+    ids.drop(safePage * grid.size).take(grid.size).forEachIndexed { index, id ->
+      val draft =
+          when (holder.surface) {
+            GuiEditableSurface.POPUP -> PopupMenuAdapter.hasDraft(plugin, id)
+            GuiEditableSurface.NORMAL -> NormalMenuAdapter.hasDraft(plugin, id)
+          }
+      inv.setItem(
+          grid[index],
+          makeItem(
+              material,
+              if (holder.surface == GuiEditableSurface.POPUP) "&d$id" else "&a$id",
+              "&7ID: &f${if (holder.surface == GuiEditableSurface.POPUP) "popup/$id" else id}",
+              "&7ドラフト: ${if (draft) "&aあり" else "&8なし"}",
+              "&7クリックで編集"))
+    }
+    if (holder.surface == GuiEditableSurface.POPUP) {
+      inv.setItem(44, makeItem(Material.WRITABLE_BOOK, "&f新規Popup", "&7/guimaker popup new <id>"))
+    } else {
+      inv.setItem(44, makeItem(Material.WRITABLE_BOOK, "&f新規通常GUI", "&7/guimaker new <id>"))
+    }
+    inv.setItem(45, makeItem(Material.ARROW, "&f編集ハブへ戻る"))
+    inv.setItem(48, makeItem(Material.ARROW, "&e前のページ", "&7${safePage + 1}/${maxPage + 1}"))
+    inv.setItem(50, makeItem(Material.ARROW, "&e次のページ", "&7${safePage + 1}/${maxPage + 1}"))
+    applyUiSkin(inv, "surface_list")
+    player.openInventory(inv)
+  }
+
+  private fun listGridSlots(): List<Int> =
+      (10..16).toList() + (19..25).toList() + (28..34).toList() + (37..43).toList()
+
   fun newSession(player: Player, menuId: String): GuiEditorSession {
     val session = GuiEditorSession(menuId)
     sessions[player.uniqueId] = session
@@ -163,6 +327,7 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
     pdc.set(KEY_PERM, PersistentDataType.STRING, def.permission ?: "")
     pdc.set(KEY_ACTIONS, PersistentDataType.STRING, serializeActions(def.actions))
     pdc.set(KEY_ENCHANTED, PersistentDataType.STRING, if (def.enchanted) "1" else "")
+    pdc.set(KEY_EXTRA, PersistentDataType.STRING, serializeExtras(def.extras))
 
     newItem.itemMeta = meta
     inv.setItem(slot, newItem)
@@ -185,6 +350,9 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
             enchanted =
                 pdc.get(KEY_ENCHANTED, PersistentDataType.STRING)?.takeIf { it.isNotEmpty() } ==
                     "1",
+            extras =
+                deserializeExtras(pdc.get(KEY_EXTRA, PersistentDataType.STRING) ?: "")
+                    .toMutableMap(),
         )
     def.actions.addAll(deserializeActions(pdc.get(KEY_ACTIONS, PersistentDataType.STRING) ?: ""))
     return def
@@ -195,6 +363,7 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
     val inv = session.canvasInventory ?: return
     session.slots.clear()
     for (slot in 0 until inv.size) {
+      if (session.surface == GuiEditableSurface.POPUP && slot in 45..53) continue
       val item = inv.getItem(slot) ?: continue
       if (item.type == Material.AIR) continue
       val def = readPdcFromItem(item) ?: continue
@@ -234,6 +403,24 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
     }
   }
 
+  private fun serializeExtras(extras: Map<String, String>): String =
+      extras.entries.joinToString("\n") { (key, value) ->
+        "$key=${value.replace(" ", "\\s").replace("\n", "\\n")}"
+      }
+
+  private fun deserializeExtras(raw: String): Map<String, String> {
+    if (raw.isBlank()) return emptyMap()
+    return raw.lines()
+        .mapNotNull { line ->
+          val eq = line.indexOf('=')
+          if (eq < 0) null
+          else
+              line.substring(0, eq) to
+                  line.substring(eq + 1).replace("\\s", " ").replace("\\n", "\n")
+        }
+        .toMap()
+  }
+
   // ── Canvas ─────────────────────────────────────────────────
 
   fun openCanvas(player: Player, session: GuiEditorSession) {
@@ -246,9 +433,11 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
     session.canvasInventory?.let { old ->
       for (i in 0 until old.size.coerceAtMost(inv.size)) {
         val item = old.getItem(i) ?: continue
+        if (session.surface == GuiEditableSurface.POPUP && i in 45..53) continue
         inv.setItem(i, decorateItem(item, session.slots[i]))
       }
     }
+    if (session.surface == GuiEditableSurface.POPUP) applyPopupReservedSlots(inv, session)
     session.canvasInventory = inv
     player.openInventory(inv)
   }
@@ -258,9 +447,14 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
   fun openPreview(player: Player, session: GuiEditorSession) {
     rebuildSlotsFromInventory(session)
     val previewSession = GuiEditorSession(session.menuId, session.menuTitle, session.menuSize)
+    previewSession.surface = session.surface
+    previewSession.popupMeta = session.popupMeta?.copy()
     session.slots.forEach { (slot, def) ->
       previewSession.slots[slot] =
-          def.copy(lore = def.lore.toMutableList(), actions = def.actions.toMutableList())
+          def.copy(
+              lore = def.lore.toMutableList(),
+              actions = def.actions.toMutableList(),
+              extras = def.extras.toMutableMap())
     }
     session.canvasInventory?.let { canvas ->
       val snapshot = Bukkit.createInventory(null, session.menuSize)
@@ -277,11 +471,18 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
       for (i in 0 until canvas.size.coerceAtMost(inv.size)) {
         val item = canvas.getItem(i) ?: continue
         if (item.type == Material.AIR) continue
+        if (previewSession.surface == GuiEditableSurface.POPUP && i in 45..53) continue
         inv.setItem(i, decorateItem(item, previewSession.slots[i]))
       }
     }
+    if (previewSession.surface == GuiEditableSurface.POPUP)
+        applyPopupReservedSlots(inv, previewSession)
     player.openInventory(inv)
-    msg(player, "&7[Preview] &fクリックでアクションをテストできます。編集に戻るには /guimaker edit ${session.menuId} canvas")
+    msg(
+        player,
+        if (session.surface == GuiEditableSurface.POPUP)
+            "&7[Preview] &f編集に戻るには /guimaker popup edit ${session.menuId}"
+        else "&7[Preview] &fクリックでアクションをテストできます。編集に戻るには /guimaker edit ${session.menuId} canvas")
   }
 
   // ── Context Menu (54-slot PlayStation Style) ───────────────
@@ -390,6 +591,10 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
     inv.setItem(12, makeItem(Material.OAK_DOOR, "&fメニューを閉じる", "&7CLOSE", "&7クリックで即追加"))
     inv.setItem(
         13, makeItem(Material.ENDER_EYE, "&b特殊メニュー", "&7OPEN_SPECIAL", "&7online_players など"))
+    inv.setItem(14, makeItem(Material.CHEST, "&eショップ", "&7OPEN_SHOP", "&7ショップカテゴリを開きます"))
+    inv.setItem(
+        15, makeItem(Material.NETHER_STAR, "&6ポイントショップ", "&7OPEN_POINT_SHOP", "&7ポイントショップカテゴリ"))
+    inv.setItem(16, makeItem(Material.GOLD_INGOT, "&6一括売却", "&7OPEN_SELL", "&7売却メニューを開きます"))
 
     // Row 2: コマンド系カテゴリ + アイテム
     inv.setItem(18, makeItem(Material.COMMAND_BLOCK, "&6コマンド系", "&7クリック時にコマンドを実行します"))
@@ -1003,6 +1208,10 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
   fun onInventoryClick(event: InventoryClickEvent) {
     val player = event.whoClicked as? Player ?: return
     when (val holder = event.inventory.holder) {
+      is HubHolder -> handleHubClick(event, player)
+      is SurfaceListHolder -> handleSurfaceListClick(event, player, holder)
+      is UiScreenListHolder -> handleUiScreenListClick(event, player, holder)
+      is SpecialSurfaceHubHolder -> handleSpecialSurfaceHubClick(event, player)
       is CanvasHolder -> handleCanvasClick(event, player, holder.session)
       is ContextHolder -> handleContextClick(event, player, holder.session, holder.slot)
       is LoreManageHolder ->
@@ -1065,8 +1274,19 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
       is PreviewHolder -> handlePreviewClick(event, player, holder.session)
       is UiSkinHolder -> handleUiSkinEditorClick(event, player, holder)
       is UiSkinBlockPickerHolder -> handleUiSkinBlockPickerClick(event, player, holder)
+      is PopupSettingsHolder -> handlePopupSettingsClick(event, player, holder)
       is TemplateHubHolder -> handleTemplateHubClick(event, player, holder)
       is TemplateDeleteConfirmHolder -> handleTemplateDeleteConfirmClick(event, player, holder)
+    }
+  }
+
+  @EventHandler(priority = EventPriority.HIGH)
+  fun onInventoryDrag(event: InventoryDragEvent) {
+    val holder = event.inventory.holder as? CanvasHolder ?: return
+    if (holder.session.surface != GuiEditableSurface.POPUP) return
+    if (event.rawSlots.any { it in 45..53 }) {
+      event.isCancelled = true
+      (event.whoClicked as? Player)?.let { msg(it, "&e[GuiMaker] &cPopup の slot 45-53 はナビバー予約です。") }
     }
   }
 
@@ -1095,6 +1315,119 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
     }
   }
 
+  private fun handleHubClick(event: InventoryClickEvent, player: Player) {
+    event.isCancelled = true
+    if (event.clickedInventory != event.inventory) return
+    when (event.rawSlot) {
+      10 -> openNormalMenuList(player)
+      12 -> openPopupMenuList(player)
+      14 -> openSpecialSurfaceHub(player)
+      16 -> openUiScreenList(player)
+      31 -> {
+        openTemplateLibrary(player)
+      }
+      49 -> {
+        player.closeInventory()
+        Bukkit.getScheduler()
+            .runTaskLater(plugin, Runnable { player.performCommand("guimaker help") }, 1L)
+      }
+      53 -> player.closeInventory()
+    }
+  }
+
+  private fun handleSurfaceListClick(
+      event: InventoryClickEvent,
+      player: Player,
+      holder: SurfaceListHolder
+  ) {
+    event.isCancelled = true
+    if (event.clickedInventory != event.inventory) return
+    val ids =
+        when (holder.surface) {
+          GuiEditableSurface.NORMAL -> NormalMenuAdapter.listIds(plugin)
+          GuiEditableSurface.POPUP -> PopupMenuAdapter.listIds(plugin)
+        }
+    val grid = listGridSlots()
+    val maxPage = ((ids.size - 1).coerceAtLeast(0)) / grid.size
+    when (event.rawSlot) {
+      45 -> openHub(player)
+      48 ->
+          when (holder.surface) {
+            GuiEditableSurface.NORMAL -> openNormalMenuList(player, holder.page - 1)
+            GuiEditableSurface.POPUP -> openPopupMenuList(player, holder.page - 1)
+          }
+      50 ->
+          when (holder.surface) {
+            GuiEditableSurface.NORMAL -> openNormalMenuList(player, holder.page + 1)
+            GuiEditableSurface.POPUP -> openPopupMenuList(player, holder.page + 1)
+          }
+      44 -> {
+        player.closeInventory()
+        val command =
+            if (holder.surface == GuiEditableSurface.POPUP) "guimaker popup new <id>"
+            else "guimaker new <id>"
+        msg(player, "&e[GuiMaker] &f新規作成: &a/$command")
+      }
+      else -> {
+        val gridIndex = grid.indexOf(event.rawSlot)
+        if (gridIndex < 0) return
+        val id = ids.getOrNull(holder.page.coerceIn(0, maxPage) * grid.size + gridIndex) ?: return
+        val session =
+            when (holder.surface) {
+              GuiEditableSurface.NORMAL -> NormalMenuAdapter.load(plugin, id)
+              GuiEditableSurface.POPUP -> PopupMenuAdapter.load(plugin, id)
+            }
+                ?: run {
+                  msg(player, "&e[GuiMaker] &c読み込みに失敗しました: &f$id")
+                  return
+                }
+        sessions[player.uniqueId] = session
+        openCanvas(player, session)
+        msg(player, "&e[GuiMaker] &a${session.displayId} を開きました。")
+      }
+    }
+  }
+
+  private fun handleUiScreenListClick(
+      event: InventoryClickEvent,
+      player: Player,
+      holder: UiScreenListHolder
+  ) {
+    event.isCancelled = true
+    if (event.clickedInventory != event.inventory) return
+    val screens = uiScreenNames()
+    val grid = listGridSlots()
+    when (event.rawSlot) {
+      45 -> openHub(player)
+      48 -> openUiScreenList(player, holder.page - 1)
+      50 -> openUiScreenList(player, holder.page + 1)
+      else -> {
+        val index = grid.indexOf(event.rawSlot)
+        if (index < 0) return
+        val screen = screens.getOrNull(holder.page * grid.size + index) ?: return
+        openUiSkinEditor(player, screen)
+      }
+    }
+  }
+
+  private fun handleSpecialSurfaceHubClick(event: InventoryClickEvent, player: Player) {
+    event.isCancelled = true
+    if (event.clickedInventory != event.inventory) return
+    when (event.rawSlot) {
+      11 -> plugin.specialMenuEngine.open(player, "online_players")
+      13 ->
+          plugin.specialMenuEngine.openConfirmCommand(
+              player, "say GuiMaker confirm sample", "player")
+      15 -> {
+        player.closeInventory()
+        msg(player, "&e[GuiMaker] &f可変コマンドはアクション種別 &aPARAM_COMMAND &fで配置します。")
+        msg(player, "&7例: &f/guimaker edit root action 10 PARAM_COMMAND \"//stack {amount}\"")
+      }
+      31 -> openNormalMenuList(player)
+      45 -> openHub(player)
+    }
+  }
+
   // ── Canvas Click ────────────────────────────────────────────
 
   private fun handleCanvasClick(
@@ -1108,6 +1441,11 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
     }
     val slot = event.rawSlot
     if (slot >= session.menuSize) return
+    if (session.surface == GuiEditableSurface.POPUP && slot in 45..53) {
+      event.isCancelled = true
+      msg(player, "&e[GuiMaker] &cPopup の slot 45-53 はナビバー予約です。")
+      return
+    }
 
     when (event.click) {
       ClickType.RIGHT,
@@ -1333,6 +1671,30 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
       }
       "特殊メニュー" -> {
         openSpecialMenuPicker(player, session, slot)
+        return
+      }
+      "ショップ" -> {
+        player.closeInventory()
+        session.pendingInput = PendingInput.ActionParam(slot, "OPEN_SHOP")
+        msg(player, "&e[GuiMaker] &fショップカテゴリIDを入力:")
+        return
+      }
+      "ポイントショップ" -> {
+        player.closeInventory()
+        session.pendingInput = PendingInput.ActionParam(slot, "OPEN_POINT_SHOP")
+        msg(player, "&e[GuiMaker] &fポイントショップカテゴリIDを入力:")
+        return
+      }
+      "一括売却" -> {
+        finishActionOrFav(
+            player,
+            session,
+            slot,
+            null,
+            GuiActionDef("OPEN_SELL"),
+            "&e[GuiMaker] &aOPEN_SELL を追加しました。") {
+              openContextMenu(player, session, slot)
+            }
         return
       }
       "メニューを閉じる" -> {
@@ -3124,7 +3486,8 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
         session.slots[TEMPLATE_BLOCK_EDIT_SLOT] =
             template.def.copy(
                 lore = template.def.lore.toMutableList(),
-                actions = template.def.actions.toMutableList())
+                actions = template.def.actions.toMutableList(),
+                extras = template.def.extras.toMutableMap())
         applyPdcToItem(session, TEMPLATE_BLOCK_EDIT_SLOT)
         msg(player, "&e[GuiMaker] &aブロックテンプレート編集を開始しました: &f${entry.id}")
         openContextMenu(player, session, TEMPLATE_BLOCK_EDIT_SLOT)
@@ -3219,7 +3582,8 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
     session.slots[targetSlot] =
         template.def.copy(
             lore = template.def.lore.toMutableList(),
-            actions = template.def.actions.toMutableList())
+            actions = template.def.actions.toMutableList(),
+            extras = template.def.extras.toMutableMap())
     applyPdcToItem(session, targetSlot)
     saveWorkingCopy(session)
     msg(player, "&e[GuiMaker] &aブロックテンプレートを配置しました: &f${entry.id} &7(slot $targetSlot)")
@@ -3236,6 +3600,7 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
   private fun firstEmptyCanvasSlot(session: GuiEditorSession): Int? {
     val inv = session.canvasInventory ?: return null
     return (0 until session.menuSize).firstOrNull {
+      if (session.surface == GuiEditableSurface.POPUP && it in 45..53) return@firstOrNull false
       inv.getItem(it)?.takeIf { item -> item.type != Material.AIR } == null
     }
   }
@@ -3292,6 +3657,99 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
     }
   }
 
+  private fun openPopupSettings(player: Player, session: GuiEditorSession) {
+    val meta = session.popupMeta ?: PopupEditorMeta().also { session.popupMeta = it }
+    val inv = Bukkit.createInventory(PopupSettingsHolder(session), 54, comp("&8Popup設定"))
+    fillMain(inv, Material.PURPLE_STAINED_GLASS_PANE)
+    inv.setItem(4, makeItem(Material.CHORUS_FRUIT, "&d${session.displayId}", "&7Popup専用設定"))
+    inv.setItem(
+        10,
+        makeItem(
+            popupGlassMaterial(meta.glass),
+            "&d背景ガラス",
+            "&7現在: &f${meta.glass}",
+            "&7左クリックで次へ / 右クリックで前へ"))
+    inv.setItem(
+        12,
+        makeItem(
+            Material.ARROW,
+            "&eNav Active -",
+            "&7現在: &f${if (meta.navActive < 0) "なし" else meta.navActive}",
+            "&7下部ナビの強調スロットを戻します"))
+    inv.setItem(
+        14,
+        makeItem(
+            Material.ARROW,
+            "&eNav Active +",
+            "&7現在: &f${if (meta.navActive < 0) "なし" else meta.navActive}",
+            "&7下部ナビの強調スロットを進めます"))
+    inv.setItem(
+        20, makeItem(Material.NAME_TAG, "&bタイトル", "&7現在: &f${session.menuTitle}", "&7クリックでタイトルを編集"))
+    inv.setItem(45, makeItem(Material.ARROW, "&fキャンバスへ戻る"))
+    inv.setItem(48, makeItem(Material.LIME_CONCRETE_POWDER, "&a反映", "&7Popup YAML に書き込みます"))
+    inv.setItem(53, makeItem(Material.ARROW, "&fキャンバスへ戻る"))
+    applyUiSkin(inv, "popup_settings")
+    player.openInventory(inv)
+  }
+
+  private fun handlePopupSettingsClick(
+      event: InventoryClickEvent,
+      player: Player,
+      holder: PopupSettingsHolder
+  ) {
+    event.isCancelled = true
+    if (event.clickedInventory != event.inventory) return
+    val session = holder.session
+    val meta = session.popupMeta ?: PopupEditorMeta().also { session.popupMeta = it }
+    when (event.rawSlot) {
+      10 -> {
+        meta.glass = nextPopupGlass(meta.glass, backwards = event.isRightClick)
+        saveWorkingCopy(session)
+        openPopupSettings(player, session)
+      }
+      12 -> {
+        meta.navActive = nextNavActive(meta.navActive, -1)
+        saveWorkingCopy(session)
+        openPopupSettings(player, session)
+      }
+      14 -> {
+        meta.navActive = nextNavActive(meta.navActive, 1)
+        saveWorkingCopy(session)
+        openPopupSettings(player, session)
+      }
+      20 -> openColorPicker(player, session, -1, "TITLE")
+      45,
+      53 -> openCanvas(player, session)
+      48 -> commitSession(player, session)
+    }
+  }
+
+  private fun popupGlassMaterial(name: String): Material =
+      runCatching { Material.valueOf(name) }.getOrDefault(Material.GRAY_STAINED_GLASS_PANE)
+
+  private fun nextPopupGlass(current: String, backwards: Boolean): String {
+    val options =
+        listOf(
+            Material.GRAY_STAINED_GLASS_PANE,
+            Material.WHITE_STAINED_GLASS_PANE,
+            Material.LIGHT_BLUE_STAINED_GLASS_PANE,
+            Material.LIME_STAINED_GLASS_PANE,
+            Material.YELLOW_STAINED_GLASS_PANE,
+            Material.ORANGE_STAINED_GLASS_PANE,
+            Material.PURPLE_STAINED_GLASS_PANE,
+            Material.RED_STAINED_GLASS_PANE,
+            Material.BLACK_STAINED_GLASS_PANE)
+    val index = options.indexOf(popupGlassMaterial(current)).takeIf { it >= 0 } ?: 0
+    val delta = if (backwards) -1 else 1
+    return options[Math.floorMod(index + delta, options.size)].name
+  }
+
+  private fun nextNavActive(current: Int, delta: Int): Int {
+    val options = listOf(-1) + NavBar.entries.map { it.slot }
+    val index = options.indexOf(current).takeIf { it >= 0 } ?: 0
+    return options[Math.floorMod(index + delta, options.size)]
+  }
+
   private fun applyEditorBar(
       player: Player,
       inv: Inventory,
@@ -3316,7 +3774,12 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
                 "&7ID: &f${templateTarget.id}"))
     inv.setItem(
         49, makeItem(Material.YELLOW_CONCRETE_POWDER, "&eテンプレート", "&7GUI/ブロックテンプレートを保存・読込します"))
-    inv.setItem(50, makeItem(Material.PURPLE_CONCRETE_POWDER, "&dタイトル", "&7メニュータイトルを変更します"))
+    inv.setItem(
+        50,
+        if (session.surface == GuiEditableSurface.POPUP)
+            makeItem(
+                Material.PURPLE_CONCRETE_POWDER, "&dPopup設定", "&7title / glass / nav_active を編集します")
+        else makeItem(Material.PURPLE_CONCRETE_POWDER, "&dタイトル", "&7メニュータイトルを変更します"))
     inv.setItem(
         51,
         if (templateTarget == null)
@@ -3338,7 +3801,9 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
       47 -> openPreview(player, session)
       48 -> if (!saveTemplateEdit(player, session)) commitSession(player, session)
       49 -> openTemplateHub(player, session)
-      50 -> openColorPicker(player, session, -1, "TITLE")
+      50 ->
+          if (session.surface == GuiEditableSurface.POPUP) openPopupSettings(player, session)
+          else openColorPicker(player, session, -1, "TITLE")
       51 -> {
         if (session.templateEditTarget != null) {
           openTemplateHub(player, session)
@@ -3346,7 +3811,13 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
           player.closeInventory()
           Bukkit.getScheduler()
               .runTaskLater(
-                  plugin, Runnable { player.performCommand("menu ${session.menuId}") }, 1L)
+                  plugin,
+                  Runnable {
+                    if (session.surface == GuiEditableSurface.POPUP)
+                        plugin.popupMenuEngine.open(player, session.menuId)
+                    else player.performCommand("menu ${session.menuId}")
+                  },
+                  1L)
         }
       }
       52 -> player.closeInventory()
@@ -3371,10 +3842,14 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
     rebuildSlotsFromInventory(session)
     val itemCount =
         session.canvasInventory?.contents?.count { it != null && it.type != Material.AIR } ?: 0
-    val hasDraft = GuiMakerExporter.hasDraft(plugin, session.menuId)
-    msg(player, "&e[GuiMaker] &fID: &a${session.menuId}")
+    val hasDraft = GuiMakerExporter.hasDraft(plugin, session)
+    msg(player, "&e[GuiMaker] &fID: &a${session.displayId}")
     msg(player, "&e[GuiMaker] &fタイトル: &a${session.menuTitle}")
     msg(player, "&e[GuiMaker] &fサイズ: &a${session.menuSize} &fアイテム数: &a$itemCount")
+    if (session.surface == GuiEditableSurface.POPUP) {
+      val meta = session.popupMeta ?: PopupEditorMeta()
+      msg(player, "&e[GuiMaker] &fPopup: glass=&a${meta.glass} &fnav_active=&a${meta.navActive}")
+    }
     msg(player, "&e[GuiMaker] &fドラフト: ${if (hasDraft) "&a保存済み" else "&7なし"}")
   }
 
@@ -3399,6 +3874,24 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
     return stack
   }
 
+  private fun applyPopupReservedSlots(inv: Inventory, session: GuiEditorSession) {
+    val active = session.popupMeta?.navActive ?: -1
+    for (slot in 45..53) {
+      val item =
+          makeItem(
+              if (slot == active) Material.LIME_STAINED_GLASS_PANE
+              else Material.RED_STAINED_GLASS_PANE,
+              if (slot == active) "&aNavBar予約: $slot" else "&cNavBar予約: $slot",
+              "&7Popupでは 45-53 は下部ナビゲーション専用です",
+              "&7このスロットにはアイテムを配置できません",
+              "&7Popup設定から nav_active を変更できます")
+      val meta = item.itemMeta ?: continue
+      meta.persistentDataContainer.set(KEY_FUNC, PersistentDataType.STRING, "popup_reserved")
+      item.itemMeta = meta
+      inv.setItem(slot, item)
+    }
+  }
+
   private fun editorHead(player: Player, session: GuiEditorSession): ItemStack {
     val stack = ItemStack(Material.PLAYER_HEAD)
     val meta = stack.itemMeta as? SkullMeta ?: return stack
@@ -3408,7 +3901,7 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
     meta.lore(
         buildList {
           if (templateTarget == null) {
-            add(comp("&7編集中: &a${session.menuId}"))
+            add(comp("&7編集中: &a${session.displayId}"))
           } else {
             add(comp("&dテンプレート編集中"))
             add(
@@ -3441,6 +3934,22 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
           .decoration(TextDecoration.ITALIC, false)
 
   // ── Holders ─────────────────────────────────────────────────
+
+  inner class HubHolder : InventoryHolder {
+    override fun getInventory(): Inventory = Bukkit.createInventory(this, 54)
+  }
+
+  inner class SurfaceListHolder(val surface: GuiEditableSurface, val page: Int) : InventoryHolder {
+    override fun getInventory(): Inventory = Bukkit.createInventory(this, 54)
+  }
+
+  inner class UiScreenListHolder(val page: Int) : InventoryHolder {
+    override fun getInventory(): Inventory = Bukkit.createInventory(this, 54)
+  }
+
+  inner class SpecialSurfaceHubHolder : InventoryHolder {
+    override fun getInventory(): Inventory = Bukkit.createInventory(this, 54)
+  }
 
   inner class CanvasHolder(val session: GuiEditorSession) : InventoryHolder {
     override fun getInventory(): Inventory =
@@ -3596,6 +4105,10 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
       val allScreens: Boolean,
       val page: Int
   ) : InventoryHolder {
+    override fun getInventory(): Inventory = Bukkit.createInventory(this, 54)
+  }
+
+  inner class PopupSettingsHolder(val session: GuiEditorSession) : InventoryHolder {
     override fun getInventory(): Inventory = Bukkit.createInventory(this, 54)
   }
 

--- a/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/guimaker/GuiEditorEngine.kt
+++ b/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/guimaker/GuiEditorEngine.kt
@@ -67,6 +67,8 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
   private val UI_SCREEN_DEFS = uiScreenCatalog.screenDefs
   private val TEMPLATE_GRID_SLOTS = (19..25).toList() + (28..34).toList() + (37..43).toList()
   private val TEMPLATE_BLOCK_EDIT_SLOT = 22
+  private val HUB_BACK_SLOT = 53
+  private val POPUP_RESERVED_BACK_SLOT = 53
 
   private enum class TemplateCategory(val displayName: String) {
     ALL("すべて"),
@@ -95,6 +97,14 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
 
     fun next(): TemplateSortMode = entries[(ordinal + 1) % entries.size]
   }
+
+  private data class SpecialBlockPreset(
+      val id: String,
+      val material: Material,
+      val name: String,
+      val lore: List<String>,
+      val actions: List<GuiActionDef>
+  )
 
   fun getSession(player: Player): GuiEditorSession? = sessions[player.uniqueId]
 
@@ -169,7 +179,7 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
     screens.drop(safePage * grid.size).take(grid.size).forEachIndexed { index, screen ->
       inv.setItem(grid[index], makeItem(Material.ITEM_FRAME, "&e$screen", "&7クリックでこの画面のUIを編集"))
     }
-    inv.setItem(45, makeItem(Material.ARROW, "&f編集ハブへ戻る"))
+    inv.setItem(HUB_BACK_SLOT, makeItem(Material.ARROW, "&f編集ハブへ戻る"))
     inv.setItem(48, makeItem(Material.ARROW, "&e前のページ", "&7${safePage + 1}/${maxPage + 1}"))
     inv.setItem(50, makeItem(Material.ARROW, "&e次のページ", "&7${safePage + 1}/${maxPage + 1}"))
     applyUiSkin(inv, "ui_screen_list")
@@ -181,32 +191,100 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
     fillMain(inv, Material.LIGHT_BLUE_STAINED_GLASS_PANE)
     inv.setItem(
         11,
-        makeItem(Material.PLAYER_HEAD, "&bオンラインプレイヤー一覧", "&7OP限定のコード駆動メニュー", "&7クリックでプレビューを開きます"))
+        makeItem(
+            Material.PLAYER_HEAD,
+            "&bオンラインプレイヤー一覧",
+            "&7OP限定のコード駆動メニュー",
+            "&a左クリック&7: 呼び出しブロックを編集",
+            "&e右クリック&7: プレビュー"))
     inv.setItem(
-        13, makeItem(Material.LIME_CONCRETE, "&a確認ボタンメニュー", "&7コマンド実行前の確認画面", "&7クリックでサンプル確認を開きます"))
+        13,
+        makeItem(
+            Material.LIME_CONCRETE,
+            "&a確認ボタンメニュー",
+            "&7コマンド実行前の確認画面",
+            "&a左クリック&7: 呼び出しブロックを編集",
+            "&e右クリック&7: サンプル確認を開く"))
     inv.setItem(
         15,
         makeItem(
             Material.REPEATER,
             "&e可変コマンドメニュー",
             "&7{amount} などの入力枠を持つコマンド",
-            "&7通常GUI/Popupのアクションから配置します"))
-    inv.setItem(45, makeItem(Material.ARROW, "&f編集ハブへ戻る"))
+            "&a左クリック&7: ブロックを編集",
+            "&e右クリック&7: 使い方を表示"))
+    inv.setItem(HUB_BACK_SLOT, makeItem(Material.ARROW, "&f編集ハブへ戻る"))
     inv.setItem(31, makeItem(Material.ENDER_CHEST, "&a通常GUIへ配置", "&7特殊メニューを呼ぶボタンを作る入口"))
     applyUiSkin(inv, "special_surface")
     player.openInventory(inv)
   }
 
   fun openTemplateLibrary(player: Player) {
+    ensureOfficialTemplateBlocks()
     val session =
         getSession(player)
             ?: NormalMenuAdapter.load(plugin, "root")?.also { sessions[player.uniqueId] = it }
-            ?: run {
-              msg(player, "&e[GuiMaker] &cテンプレート管理は通常GUI編集中に開いてください。")
-              return
-            }
+            ?: createTemplateWorkspaceSession().also { sessions[player.uniqueId] = it }
     openTemplateHub(player, session)
   }
+
+  private fun createTemplateWorkspaceSession(): GuiEditorSession {
+    val session = GuiEditorSession("guimaker_template_workspace", "&8テンプレート編集ワークスペース", 54)
+    session.canvasInventory = Bukkit.createInventory(null, 54)
+    return session
+  }
+
+  private fun ensureOfficialTemplateBlocks() {
+    specialBlockPresets().forEach { preset ->
+      val def =
+          GuiSlotDef(
+              name = preset.name,
+              lore = preset.lore.toMutableList(),
+              actions = preset.actions.map { it.copy(params = it.params.toMap()) }.toMutableList())
+      GuiTemplateStore.ensureSharedBlockTemplate(
+          plugin, "special/${preset.id}", preset.material, def)
+    }
+  }
+
+  private fun specialBlockPresets(): List<SpecialBlockPreset> =
+      listOf(
+          SpecialBlockPreset(
+              id = "online_players",
+              material = Material.PLAYER_HEAD,
+              name = "&bオンラインプレイヤー一覧",
+              lore = listOf("&7OP限定のオンラインプレイヤー一覧を開きます", "&7クリックしたプレイヤーへ /tp します"),
+              actions = listOf(GuiActionDef("OPEN_SPECIAL", mapOf("target" to "online_players")))),
+          SpecialBlockPreset(
+              id = "confirm_command",
+              material = Material.LIME_CONCRETE,
+              name = "&a確認ボタンメニュー",
+              lore = listOf("&7実行前に確認ボタンを表示します", "&7command はアクション詳細から確認してください"),
+              actions =
+                  listOf(
+                      GuiActionDef(
+                          "OPEN_SPECIAL",
+                          mapOf(
+                              "target" to "confirm",
+                              "command" to "say GuiMaker confirm sample",
+                              "mode" to "player")))),
+          SpecialBlockPreset(
+              id = "parameter_command",
+              material = Material.REPEATER,
+              name = "&e可変コマンドメニュー",
+              lore = listOf("&7{amount} の値をGUIで増減して実行します", "&7例: //stack {amount}"),
+              actions =
+                  listOf(
+                      GuiActionDef(
+                          "PARAM_COMMAND",
+                          mapOf(
+                              "command" to "//stack {amount}",
+                              "mode" to "op",
+                              "confirm" to "true",
+                              "param.amount.type" to "int",
+                              "param.amount.default" to "10",
+                              "param.amount.min" to "1",
+                              "param.amount.max" to "100",
+                              "param.amount.step" to "1")))))
 
   private fun getFavorites(playerId: UUID): MutableList<GuiActionDef> =
       playerFavorites.getOrPut(playerId) { loadFavoritesFromDisk(playerId) }
@@ -288,7 +366,7 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
     } else {
       inv.setItem(44, makeItem(Material.WRITABLE_BOOK, "&f新規通常GUI", "&7/guimaker new <id>"))
     }
-    inv.setItem(45, makeItem(Material.ARROW, "&f編集ハブへ戻る"))
+    inv.setItem(HUB_BACK_SLOT, makeItem(Material.ARROW, "&f編集ハブへ戻る"))
     inv.setItem(48, makeItem(Material.ARROW, "&e前のページ", "&7${safePage + 1}/${maxPage + 1}"))
     inv.setItem(50, makeItem(Material.ARROW, "&e次のページ", "&7${safePage + 1}/${maxPage + 1}"))
     applyUiSkin(inv, "surface_list")
@@ -709,6 +787,13 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
                 .map { "&7${it.key}: &f${it.value}" }
                 .ifEmpty { listOf("&8パラメータなし") }
                 .toTypedArray()))
+    inv.setItem(
+        31,
+        makeItem(
+            Material.WRITABLE_BOOK,
+            "&e詳細パラメータを編集",
+            "&7key=value 形式で複数指定します",
+            "&7例: &fcommand=\"//stack {amount}\" confirm=true mode=op"))
 
     // Row 4: 追加・削除
     inv.setItem(37, makeItem(Material.COMMAND_BLOCK, "&aアクションを追加", "&7新しいアクションを末尾に追加します"))
@@ -1318,20 +1403,20 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
   private fun handleHubClick(event: InventoryClickEvent, player: Player) {
     event.isCancelled = true
     if (event.clickedInventory != event.inventory) return
-    when (event.rawSlot) {
-      10 -> openNormalMenuList(player)
-      12 -> openPopupMenuList(player)
-      14 -> openSpecialSurfaceHub(player)
-      16 -> openUiScreenList(player)
-      31 -> {
+    when (funcLabelAt("hub", event.rawSlot)) {
+      "通常GUI" -> openNormalMenuList(player)
+      "Popupメニュー" -> openPopupMenuList(player)
+      "特殊メニュー" -> openSpecialSurfaceHub(player)
+      "GUI Maker UI" -> openUiScreenList(player)
+      "テンプレート / 公式ブロック" -> {
         openTemplateLibrary(player)
       }
-      49 -> {
+      "ヘルプ" -> {
         player.closeInventory()
         Bukkit.getScheduler()
             .runTaskLater(plugin, Runnable { player.performCommand("guimaker help") }, 1L)
       }
-      53 -> player.closeInventory()
+      "閉じる" -> player.closeInventory()
     }
   }
 
@@ -1349,19 +1434,21 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
         }
     val grid = listGridSlots()
     val maxPage = ((ids.size - 1).coerceAtLeast(0)) / grid.size
-    when (event.rawSlot) {
-      45 -> openHub(player)
-      48 ->
+    when (funcLabelAt("surface_list", event.rawSlot)) {
+      "編集ハブへ戻る" -> openHub(player)
+      "前のページ" ->
           when (holder.surface) {
-            GuiEditableSurface.NORMAL -> openNormalMenuList(player, holder.page - 1)
-            GuiEditableSurface.POPUP -> openPopupMenuList(player, holder.page - 1)
+            GuiEditableSurface.NORMAL ->
+                openNormalMenuList(player, holder.page.coerceAtLeast(0) - 1)
+            GuiEditableSurface.POPUP -> openPopupMenuList(player, holder.page.coerceAtLeast(0) - 1)
           }
-      50 ->
+      "次のページ" ->
           when (holder.surface) {
-            GuiEditableSurface.NORMAL -> openNormalMenuList(player, holder.page + 1)
-            GuiEditableSurface.POPUP -> openPopupMenuList(player, holder.page + 1)
+            GuiEditableSurface.NORMAL ->
+                openNormalMenuList(player, holder.page.coerceAtLeast(0) + 1)
+            GuiEditableSurface.POPUP -> openPopupMenuList(player, holder.page.coerceAtLeast(0) + 1)
           }
-      44 -> {
+      "新規作成" -> {
         player.closeInventory()
         val command =
             if (holder.surface == GuiEditableSurface.POPUP) "guimaker popup new <id>"
@@ -1397,14 +1484,15 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
     if (event.clickedInventory != event.inventory) return
     val screens = uiScreenNames()
     val grid = listGridSlots()
-    when (event.rawSlot) {
-      45 -> openHub(player)
-      48 -> openUiScreenList(player, holder.page - 1)
-      50 -> openUiScreenList(player, holder.page + 1)
+    when (funcLabelAt("ui_screen_list", event.rawSlot)) {
+      "編集ハブへ戻る" -> openHub(player)
+      "前のページ" -> openUiScreenList(player, holder.page.coerceAtLeast(0) - 1)
+      "次のページ" -> openUiScreenList(player, holder.page.coerceAtLeast(0) + 1)
       else -> {
         val index = grid.indexOf(event.rawSlot)
         if (index < 0) return
-        val screen = screens.getOrNull(holder.page * grid.size + index) ?: return
+        val safePage = holder.page.coerceIn(0, ((screens.size - 1).coerceAtLeast(0)) / grid.size)
+        val screen = screens.getOrNull(safePage * grid.size + index) ?: return
         openUiSkinEditor(player, screen)
       }
     }
@@ -1413,19 +1501,57 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
   private fun handleSpecialSurfaceHubClick(event: InventoryClickEvent, player: Player) {
     event.isCancelled = true
     if (event.clickedInventory != event.inventory) return
-    when (event.rawSlot) {
-      11 -> plugin.specialMenuEngine.open(player, "online_players")
-      13 ->
-          plugin.specialMenuEngine.openConfirmCommand(
-              player, "say GuiMaker confirm sample", "player")
-      15 -> {
-        player.closeInventory()
-        msg(player, "&e[GuiMaker] &f可変コマンドはアクション種別 &aPARAM_COMMAND &fで配置します。")
-        msg(player, "&7例: &f/guimaker edit root action 10 PARAM_COMMAND \"//stack {amount}\"")
-      }
-      31 -> openNormalMenuList(player)
-      45 -> openHub(player)
+    when (funcLabelAt("special_surface", event.rawSlot)) {
+      "オンラインプレイヤー一覧" ->
+          if (event.isRightClick) plugin.specialMenuEngine.open(player, "online_players")
+          else openSpecialBlockEditor(player, "online_players")
+      "確認ボタンメニュー" ->
+          if (event.isRightClick)
+              plugin.specialMenuEngine.openConfirmCommand(
+                  player, "say GuiMaker confirm sample", "player")
+          else openSpecialBlockEditor(player, "confirm_command")
+      "可変コマンドメニュー" ->
+          if (event.isRightClick) {
+            player.closeInventory()
+            msg(player, "&e[GuiMaker] &f可変コマンドはアクション種別 &aPARAM_COMMAND &fで配置します。")
+            msg(player, "&7例: &f/guimaker edit root action 10 PARAM_COMMAND \"//stack {amount}\"")
+          } else {
+            openSpecialBlockEditor(player, "parameter_command")
+          }
+      "通常GUIへ配置" -> openNormalMenuList(player)
+      "編集ハブへ戻る" -> openHub(player)
     }
+  }
+
+  private fun openSpecialBlockEditor(player: Player, presetId: String) {
+    val preset =
+        specialBlockPresets().firstOrNull { it.id == presetId }
+            ?: run {
+              msg(player, "&e[GuiMaker] &c特殊ブロックが見つかりません: &f$presetId")
+              return
+            }
+    ensureOfficialTemplateBlocks()
+    val session = GuiEditorSession("special_blocks/${preset.id}", "&8特殊ブロック: ${preset.id}", 54)
+    val def =
+        GuiSlotDef(
+            name = preset.name,
+            lore = preset.lore.toMutableList(),
+            actions = preset.actions.map { it.copy(params = it.params.toMap()) }.toMutableList())
+    session.contextSlot = TEMPLATE_BLOCK_EDIT_SLOT
+    session.templateEditTarget =
+        GuiTemplateStore.listTemplates(plugin, player).firstOrNull {
+          it.scope == GuiTemplateScope.SHARED &&
+              it.kind == GuiTemplateKind.BLOCK &&
+              it.id == "special/${preset.id}"
+        }
+    session.canvasInventory = Bukkit.createInventory(null, session.menuSize)
+    session.canvasInventory?.setItem(
+        TEMPLATE_BLOCK_EDIT_SLOT, GuiTemplateStore.buildBlockItem(preset.material, def))
+    session.slots[TEMPLATE_BLOCK_EDIT_SLOT] = def
+    sessions[player.uniqueId] = session
+    applyPdcToItem(session, TEMPLATE_BLOCK_EDIT_SLOT)
+    msg(player, "&e[GuiMaker] &a特殊ブロック編集を開始しました: &f${preset.id}")
+    openContextMenu(player, session, TEMPLATE_BLOCK_EDIT_SLOT)
   }
 
   // ── Canvas Click ────────────────────────────────────────────
@@ -1443,6 +1569,10 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
     if (slot >= session.menuSize) return
     if (session.surface == GuiEditableSurface.POPUP && slot in 45..53) {
       event.isCancelled = true
+      if (slot == POPUP_RESERVED_BACK_SLOT) {
+        openPopupSettings(player, session)
+        return
+      }
       msg(player, "&e[GuiMaker] &cPopup の slot 45-53 はナビバー予約です。")
       return
     }
@@ -1620,6 +1750,12 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
             }
     when (funcLabelAt("action_edit", event.rawSlot)) {
       "値を編集" -> startActionValueEdit(player, session, slot, actionIndex, action)
+      "詳細パラメータを編集" -> {
+        player.closeInventory()
+        session.pendingInput = PendingInput.ActionRawParams(slot, actionIndex)
+        msg(player, "&e[GuiMaker] &f詳細パラメータを key=value 形式で入力してください。")
+        msg(player, "&7例: &fcommand=\"//stack {amount}\" confirm=true mode=op")
+      }
       "上へ移動" -> {
         if (actionIndex > 0) {
           java.util.Collections.swap(actions, actionIndex, actionIndex - 1)
@@ -2342,16 +2478,53 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
         msg(player, "&e[GuiMaker] &a権限を設定: &f${def.permission ?: "(なし)"}")
       }
       is PendingInput.ActionParam -> {
-        val action =
-            GuiActionDef(
-                pending.actionType,
-                GuiActionCatalog.params(
-                    pending.actionType, text, formatVolume(session.soundVolume)))
+        val existingParams =
+            pending.actionIndex
+                ?.let { session.slots[pending.slot]?.actions?.getOrNull(it)?.params }
+                .orEmpty()
+        val actionParams =
+            existingParams.toMutableMap().also {
+              it.putAll(
+                  GuiActionCatalog.params(
+                      pending.actionType, text, formatVolume(session.soundVolume)))
+            }
+        val action = GuiActionDef(pending.actionType, actionParams)
         val successMsg =
             "&e[GuiMaker] &a${pending.actionType} を${if (pending.actionIndex == null) "追加" else "更新"}: &f$text"
         finishActionOrFav(player, session, pending.slot, pending.actionIndex, action, successMsg) {
           openContextMenu(player, session, pending.slot)
         }
+        return
+      }
+      is PendingInput.ActionRawParams -> {
+        val actions = session.slots[pending.slot]?.actions
+        val current = actions?.getOrNull(pending.actionIndex)
+        if (actions == null || current == null) {
+          msg(player, "&e[GuiMaker] &c編集対象のアクションが見つかりません。")
+          openContextMenu(player, session, pending.slot)
+          return
+        }
+        val parsed =
+            parseKeyValuePairs(text)
+                ?: run {
+                  msg(
+                      player,
+                      "&e[GuiMaker] &c形式が正しくありません。例: command=\"//stack {amount}\" confirm=true")
+                  openActionEditMenu(player, session, pending.slot, pending.actionIndex)
+                  return
+                }
+        if (parsed.isEmpty()) {
+          msg(player, "&e[GuiMaker] &c更新する key=value がありません。")
+          openActionEditMenu(player, session, pending.slot, pending.actionIndex)
+          return
+        }
+        val params = current.params.toMutableMap()
+        params.putAll(parsed)
+        actions[pending.actionIndex] = current.copy(params = params)
+        applyPdcToItem(session, pending.slot)
+        saveWorkingCopy(session)
+        msg(player, "&e[GuiMaker] &a詳細パラメータを更新しました: &f${parsed.keys.joinToString()}")
+        openActionEditMenu(player, session, pending.slot, pending.actionIndex)
         return
       }
       is PendingInput.MenuTitle -> {
@@ -2374,6 +2547,48 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
       }
     }
     return unescaped
+  }
+
+  private fun parseKeyValuePairs(raw: String): Map<String, String>? {
+    val tokens = splitKeyValueTokens(raw) ?: return null
+    val result = linkedMapOf<String, String>()
+    for (token in tokens) {
+      val eq = token.indexOf('=')
+      if (eq <= 0) return null
+      val key = token.substring(0, eq).trim()
+      if (key.isBlank()) return null
+      result[key] = token.substring(eq + 1)
+    }
+    return result
+  }
+
+  private fun splitKeyValueTokens(raw: String): List<String>? {
+    val tokens = mutableListOf<String>()
+    val current = StringBuilder()
+    var quote: Char? = null
+    var escaped = false
+    raw.trim().forEach { ch ->
+      when {
+        escaped -> {
+          current.append(ch)
+          escaped = false
+        }
+        quote != null && ch == '\\' -> escaped = true
+        quote != null && ch == quote -> quote = null
+        quote != null -> current.append(ch)
+        ch == '"' || ch == '\'' -> quote = ch
+        ch.isWhitespace() -> {
+          if (current.isNotEmpty()) {
+            tokens += current.toString()
+            current.clear()
+          }
+        }
+        else -> current.append(ch)
+      }
+    }
+    if (escaped || quote != null) return null
+    if (current.isNotEmpty()) tokens += current.toString()
+    return tokens
   }
 
   // ── 直接操作 API (コマンドから呼び出す) ─────────────────────
@@ -3306,6 +3521,7 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
         makeItem(
             Material.NETHER_STAR,
             "&6公式テンプレート",
+            "&7クリックで公式テンプレートだけ表示します",
             "&7OPコマンドで個人テンプレートを承認します",
             "&f/guimaker template approve <player> <menu|block> <id> [official-id]"))
 
@@ -3413,6 +3629,10 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
           msgResult(player, result, "ブロックテンプレートを保存しました")
         }
         openTemplateHub(player, session, holder.page, TemplateCategory.BLOCK, holder.sortMode)
+        return
+      }
+      "公式テンプレート" -> {
+        openTemplateHub(player, session, 0, TemplateCategory.SHARED, holder.sortMode)
         return
       }
       "前のページ" -> {
@@ -3685,9 +3905,8 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
             "&7下部ナビの強調スロットを進めます"))
     inv.setItem(
         20, makeItem(Material.NAME_TAG, "&bタイトル", "&7現在: &f${session.menuTitle}", "&7クリックでタイトルを編集"))
-    inv.setItem(45, makeItem(Material.ARROW, "&fキャンバスへ戻る"))
     inv.setItem(48, makeItem(Material.LIME_CONCRETE_POWDER, "&a反映", "&7Popup YAML に書き込みます"))
-    inv.setItem(53, makeItem(Material.ARROW, "&fキャンバスへ戻る"))
+    inv.setItem(HUB_BACK_SLOT, makeItem(Material.ARROW, "&fキャンバスへ戻る"))
     applyUiSkin(inv, "popup_settings")
     player.openInventory(inv)
   }
@@ -3701,26 +3920,25 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
     if (event.clickedInventory != event.inventory) return
     val session = holder.session
     val meta = session.popupMeta ?: PopupEditorMeta().also { session.popupMeta = it }
-    when (event.rawSlot) {
-      10 -> {
+    when (funcLabelAt("popup_settings", event.rawSlot)) {
+      "背景ガラス" -> {
         meta.glass = nextPopupGlass(meta.glass, backwards = event.isRightClick)
         saveWorkingCopy(session)
         openPopupSettings(player, session)
       }
-      12 -> {
+      "Nav Active -" -> {
         meta.navActive = nextNavActive(meta.navActive, -1)
         saveWorkingCopy(session)
         openPopupSettings(player, session)
       }
-      14 -> {
+      "Nav Active +" -> {
         meta.navActive = nextNavActive(meta.navActive, 1)
         saveWorkingCopy(session)
         openPopupSettings(player, session)
       }
-      20 -> openColorPicker(player, session, -1, "TITLE")
-      45,
-      53 -> openCanvas(player, session)
-      48 -> commitSession(player, session)
+      "タイトル" -> openColorPicker(player, session, -1, "TITLE")
+      "キャンバスへ戻る" -> openCanvas(player, session)
+      "反映" -> commitSession(player, session)
     }
   }
 
@@ -3878,15 +4096,26 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
     val active = session.popupMeta?.navActive ?: -1
     for (slot in 45..53) {
       val item =
-          makeItem(
-              if (slot == active) Material.LIME_STAINED_GLASS_PANE
-              else Material.RED_STAINED_GLASS_PANE,
-              if (slot == active) "&aNavBar予約: $slot" else "&cNavBar予約: $slot",
-              "&7Popupでは 45-53 は下部ナビゲーション専用です",
-              "&7このスロットにはアイテムを配置できません",
-              "&7Popup設定から nav_active を変更できます")
+          if (slot == POPUP_RESERVED_BACK_SLOT) {
+            makeItem(
+                Material.ARROW,
+                "&fPopup設定へ戻る",
+                "&7Popupでは 45-53 は下部ナビゲーション専用です",
+                "&7クリックで Popup設定へ戻ります")
+          } else {
+            makeItem(
+                if (slot == active) Material.LIME_STAINED_GLASS_PANE
+                else Material.RED_STAINED_GLASS_PANE,
+                if (slot == active) "&aNavBar予約: $slot" else "&cNavBar予約: $slot",
+                "&7Popupでは 45-53 は下部ナビゲーション専用です",
+                "&7このスロットにはアイテムを配置できません",
+                "&7Popup設定から nav_active を変更できます")
+          }
       val meta = item.itemMeta ?: continue
-      meta.persistentDataContainer.set(KEY_FUNC, PersistentDataType.STRING, "popup_reserved")
+      meta.persistentDataContainer.set(
+          KEY_FUNC,
+          PersistentDataType.STRING,
+          if (slot == POPUP_RESERVED_BACK_SLOT) "popup_reserved_back" else "popup_reserved")
       item.itemMeta = meta
       inv.setItem(slot, item)
     }

--- a/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/guimaker/GuiEditorEngine.kt
+++ b/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/guimaker/GuiEditorEngine.kt
@@ -1,6 +1,8 @@
 package com.github.sahyuya.oyasaiMenu.guimaker
 
 import com.github.sahyuya.oyasaiMenu.OyasaiMenu
+import com.github.sahyuya.oyasaiMenu.model.ActionType
+import com.github.sahyuya.oyasaiMenu.model.MenuAction
 import com.github.sahyuya.oyasaiMenu.util.ItemVisuals
 import java.util.Locale
 import java.util.UUID
@@ -386,6 +388,8 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
     inv.setItem(10, makeItem(Material.ENDER_CHEST, "&aメニューを開く", "&7OPEN_MENU", "&7既存メニューをGUIで選択"))
     inv.setItem(11, makeItem(Material.CHORUS_FRUIT, "&dポップアップ", "&7OPEN_POPUP", "&7ポップアップをGUIで選択"))
     inv.setItem(12, makeItem(Material.OAK_DOOR, "&fメニューを閉じる", "&7CLOSE", "&7クリックで即追加"))
+    inv.setItem(
+        13, makeItem(Material.ENDER_EYE, "&b特殊メニュー", "&7OPEN_SPECIAL", "&7online_players など"))
 
     // Row 2: コマンド系カテゴリ + アイテム
     inv.setItem(18, makeItem(Material.COMMAND_BLOCK, "&6コマンド系", "&7クリック時にコマンドを実行します"))
@@ -397,6 +401,9 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
     inv.setItem(21, makeItem(Material.NETHER_STAR, "&cOPコマンド", "&7OP_PLAYER_CMD", "&7一時OP権限で実行"))
     inv.setItem(
         22, makeItem(Material.COMMAND_BLOCK, "&aコマンドを提案", "&7SUGGEST_COMMAND", "&7クリックでチャット欄に入力"))
+    inv.setItem(
+        23,
+        makeItem(Material.REPEATER, "&e可変コマンド", "&7PARAM_COMMAND", "&7{amount} などの入力枠を持つOP限定コマンド"))
 
     // Row 3: メッセージ系カテゴリ + アイテム
     inv.setItem(27, makeItem(Material.PAPER, "&fメッセージ系", "&7チャットへ情報を表示します"))
@@ -868,6 +875,45 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
     player.openInventory(inv)
   }
 
+  private fun openSpecialMenuPicker(
+      player: Player,
+      session: GuiEditorSession,
+      canvasSlot: Int,
+      actionIndex: Int? = null
+  ) {
+    val entries =
+        listOf(
+            SpecialMenuChoice(
+                "online_players",
+                Material.PLAYER_HEAD,
+                "&bオンラインプレイヤー",
+                listOf("&7オンラインプレイヤー一覧を開きます", "&7クリックで /tp <player>")),
+            SpecialMenuChoice(
+                "confirm",
+                Material.LIME_CONCRETE,
+                "&a確認メニュー",
+                listOf("&7実行前の確認画面です", "&7手入力で command を指定してください")))
+    val gridSlots = listOf(20, 24)
+    val slotToId = entries.mapIndexed { i, entry -> gridSlots[i] to entry.id }.toMap()
+    val inv =
+        Bukkit.createInventory(
+            SpecialMenuPickHolder(session, canvasSlot, actionIndex, slotToId),
+            54,
+            comp("&9GuiMaker &8- &b特殊メニュー"))
+    placeItemPreview(inv, session, canvasSlot)
+    inv.setItem(0, makeItem(Material.ENDER_EYE, "&b特殊メニュー", "&7コード生成メニューを選択します"))
+    entries.forEachIndexed { i, entry ->
+      inv.setItem(
+          gridSlots[i],
+          makeItem(entry.material, entry.name, "&7ID: &f${entry.id}", *entry.lore.toTypedArray()))
+    }
+    inv.setItem(44, makeItem(Material.WRITABLE_BOOK, "&fIDを手入力", "&7一覧にない特殊メニューIDを直接入力"))
+    fillMain(inv, Material.LIGHT_BLUE_STAINED_GLASS_PANE)
+    applyEditorBar(player, inv, session, "&fアクション選択に戻る", "&7アクション種類の選択へ戻ります")
+    applyUiSkin(inv, "special_pick")
+    player.openInventory(inv)
+  }
+
   // ── Favorites Manager ──────────────────────────────────────
 
   private fun openFavoritesManage(player: Player, session: GuiEditorSession, canvasSlot: Int) {
@@ -1008,6 +1054,9 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
               event, player, holder.session, holder.canvasSlot, holder.actionIndex, holder.slotToId)
       is MenuIdPickHolder ->
           handleMenuPickClick(
+              event, player, holder.session, holder.canvasSlot, holder.actionIndex, holder.slotToId)
+      is SpecialMenuPickHolder ->
+          handleSpecialMenuPickClick(
               event, player, holder.session, holder.canvasSlot, holder.actionIndex, holder.slotToId)
       is FavManageHolder -> handleFavManageClick(event, player, holder.session, holder.canvasSlot)
       is ConfirmHolder ->
@@ -1280,6 +1329,10 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
       }
       "ポップアップ" -> {
         openPopupPicker(player, session, slot)
+        return
+      }
+      "特殊メニュー" -> {
+        openSpecialMenuPicker(player, session, slot)
         return
       }
       "メニューを閉じる" -> {
@@ -1582,7 +1635,7 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
         session.pendingInput = PendingInput.ActionParam(canvasSlot, "OPEN_POPUP", actionIndex)
         msg(player, "&e[GuiMaker] &fポップアップIDを入力:")
       }
-      null -> {
+      else -> {
         val id = slotToId[event.rawSlot] ?: return
         finishActionOrFav(
             player,
@@ -1594,7 +1647,6 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
               openContextMenu(player, session, canvasSlot)
             }
       }
-      else -> {}
     }
   }
 
@@ -1634,6 +1686,49 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
       else -> {}
     }
   }
+
+  private fun handleSpecialMenuPickClick(
+      event: InventoryClickEvent,
+      player: Player,
+      session: GuiEditorSession,
+      canvasSlot: Int,
+      actionIndex: Int?,
+      slotToId: Map<Int, String>
+  ) {
+    event.isCancelled = true
+    if (event.clickedInventory != event.inventory) return
+    if (handleEditorBarClick(event.rawSlot, player, session) {
+      if (actionIndex == null) openActionTypeMenu(player, session, canvasSlot)
+      else openActionEditMenu(player, session, canvasSlot, actionIndex)
+    })
+        return
+    when (funcLabelAt("special_pick", event.rawSlot)) {
+      "IDを手入力" -> {
+        player.closeInventory()
+        session.pendingInput = PendingInput.ActionParam(canvasSlot, "OPEN_SPECIAL", actionIndex)
+        msg(player, "&e[GuiMaker] &f特殊メニューIDを入力:")
+      }
+      else -> {
+        val id = slotToId[event.rawSlot] ?: return
+        finishActionOrFav(
+            player,
+            session,
+            canvasSlot,
+            actionIndex,
+            GuiActionDef("OPEN_SPECIAL", mapOf("target" to id)),
+            "&e[GuiMaker] &aOPEN_SPECIAL ($id) を${if (actionIndex == null) "追加" else "更新"}しました。") {
+              openContextMenu(player, session, canvasSlot)
+            }
+      }
+    }
+  }
+
+  private data class SpecialMenuChoice(
+      val id: String,
+      val material: Material,
+      val name: String,
+      val lore: List<String>
+  )
 
   // ── Confirm Click ───────────────────────────────────────────
 
@@ -1790,6 +1885,9 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
                 player,
                 action.params["sound"] ?: "ui.button.click",
                 action.params["volume"]?.toFloatOrNull() ?: 1.0f)
+        "PARAM_COMMAND" ->
+            plugin.parameterCommandEngine.open(
+                player, MenuAction(ActionType.PARAM_COMMAND, action.params))
         "CLOSE" -> player.closeInventory()
         "OPEN_MENU" ->
             Bukkit.getScheduler()
@@ -1807,6 +1905,7 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
                       player.performCommand("menu ${action.params["target"] ?: return@Runnable}")
                     },
                     1L)
+        "OPEN_SPECIAL" -> plugin.specialMenuEngine.open(player, action.params["target"] ?: "", null)
         "URL" -> player.sendMessage(comp("&e${action.params["url"] ?: ""}"))
         "CHAT_PASTE" -> player.sendMessage(comp("&7: &f${action.params["text"] ?: ""}"))
         "SUGGEST_COMMAND" -> player.sendMessage(comp("&a▶ &e${action.params["command"] ?: ""}"))
@@ -1820,11 +1919,12 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
   fun onCommandWhilePendingInput(event: PlayerCommandPreprocessEvent) {
     val player = event.player
     val session = sessions[player.uniqueId] ?: return
-    if (session.pendingInput == null) return
+    val pending = session.pendingInput ?: return
 
     event.isCancelled = true
     session.pendingInput = null
-    msg(player, "&e[GuiMaker] &c入力待ちをキャンセルしました。もう一度GUIから操作してください。")
+    Bukkit.getScheduler()
+        .runTask(plugin, Runnable { handlePendingInput(player, session, pending, event.message) })
   }
 
   @Suppress("DEPRECATION")
@@ -1836,64 +1936,82 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
 
     event.isCancelled = true
     session.pendingInput = null
-    val text = event.message
+    val text = normalizeTypedInput(event.message)
 
     Bukkit.getScheduler()
-        .runTask(
-            plugin,
-            Runnable {
-              when (pending) {
-                is PendingInput.ItemName -> {
-                  val full = pending.color + text
-                  session.slots.getOrPut(pending.slot) { GuiSlotDef() }.name = full
-                  applyPdcToItem(session, pending.slot)
-                  msg(player, "&e[GuiMaker] &a名前を設定: &f$full")
-                }
-                is PendingInput.LoreLine -> {
-                  val full = pending.color + text
-                  session.slots.getOrPut(pending.slot) { GuiSlotDef() }.lore.add(full)
-                  applyPdcToItem(session, pending.slot)
-                  msg(player, "&e[GuiMaker] &aロア行を追加: &f$full")
-                }
-                is PendingInput.LoreEdit -> {
-                  val full = pending.color + text
-                  val lore = session.slots.getOrPut(pending.slot) { GuiSlotDef() }.lore
-                  if (pending.lineIndex in lore.indices) {
-                    lore[pending.lineIndex] = full
-                    applyPdcToItem(session, pending.slot)
-                    msg(player, "&e[GuiMaker] &aロア行 ${pending.lineIndex + 1} を更新: &f$full")
-                  } else {
-                    msg(player, "&e[GuiMaker] &cロア行が見つかりません。")
-                  }
-                }
-                is PendingInput.Permission -> {
-                  val def = session.slots.getOrPut(pending.slot) { GuiSlotDef() }
-                  def.permission = text.ifBlank { null }
-                  applyPdcToItem(session, pending.slot)
-                  msg(player, "&e[GuiMaker] &a権限を設定: &f${def.permission ?: "(なし)"}")
-                }
-                is PendingInput.ActionParam -> {
-                  val action =
-                      GuiActionDef(
-                          pending.actionType,
-                          GuiActionCatalog.params(
-                              pending.actionType, text, formatVolume(session.soundVolume)))
-                  val successMsg =
-                      "&e[GuiMaker] &a${pending.actionType} を${if (pending.actionIndex == null) "追加" else "更新"}: &f$text"
-                  finishActionOrFav(
-                      player, session, pending.slot, pending.actionIndex, action, successMsg) {
-                        openContextMenu(player, session, pending.slot)
-                      }
-                  return@Runnable
-                }
-                is PendingInput.MenuTitle -> {
-                  session.menuTitle = pending.color + text
-                  msg(player, "&e[GuiMaker] &aタイトルを設定: &f${session.menuTitle}")
-                }
-              }
-              saveWorkingCopy(session)
-              openCanvas(player, session)
-            })
+        .runTask(plugin, Runnable { handlePendingInput(player, session, pending, text) })
+  }
+
+  private fun handlePendingInput(
+      player: Player,
+      session: GuiEditorSession,
+      pending: PendingInput,
+      rawText: String
+  ) {
+    val text = normalizeTypedInput(rawText)
+    when (pending) {
+      is PendingInput.ItemName -> {
+        val full = pending.color + text
+        session.slots.getOrPut(pending.slot) { GuiSlotDef() }.name = full
+        applyPdcToItem(session, pending.slot)
+        msg(player, "&e[GuiMaker] &a名前を設定: &f$full")
+      }
+      is PendingInput.LoreLine -> {
+        val full = pending.color + text
+        session.slots.getOrPut(pending.slot) { GuiSlotDef() }.lore.add(full)
+        applyPdcToItem(session, pending.slot)
+        msg(player, "&e[GuiMaker] &aロア行を追加: &f$full")
+      }
+      is PendingInput.LoreEdit -> {
+        val full = pending.color + text
+        val lore = session.slots.getOrPut(pending.slot) { GuiSlotDef() }.lore
+        if (pending.lineIndex in lore.indices) {
+          lore[pending.lineIndex] = full
+          applyPdcToItem(session, pending.slot)
+          msg(player, "&e[GuiMaker] &aロア行 ${pending.lineIndex + 1} を更新: &f$full")
+        } else {
+          msg(player, "&e[GuiMaker] &cロア行が見つかりません。")
+        }
+      }
+      is PendingInput.Permission -> {
+        val def = session.slots.getOrPut(pending.slot) { GuiSlotDef() }
+        def.permission = text.ifBlank { null }
+        applyPdcToItem(session, pending.slot)
+        msg(player, "&e[GuiMaker] &a権限を設定: &f${def.permission ?: "(なし)"}")
+      }
+      is PendingInput.ActionParam -> {
+        val action =
+            GuiActionDef(
+                pending.actionType,
+                GuiActionCatalog.params(
+                    pending.actionType, text, formatVolume(session.soundVolume)))
+        val successMsg =
+            "&e[GuiMaker] &a${pending.actionType} を${if (pending.actionIndex == null) "追加" else "更新"}: &f$text"
+        finishActionOrFav(player, session, pending.slot, pending.actionIndex, action, successMsg) {
+          openContextMenu(player, session, pending.slot)
+        }
+        return
+      }
+      is PendingInput.MenuTitle -> {
+        session.menuTitle = pending.color + text
+        msg(player, "&e[GuiMaker] &aタイトルを設定: &f${session.menuTitle}")
+      }
+    }
+    saveWorkingCopy(session)
+    openCanvas(player, session)
+  }
+
+  private fun normalizeTypedInput(raw: String): String {
+    val text = raw.trim()
+    val unescaped = if (text.startsWith("\\/")) text.removePrefix("\\") else text
+    if (unescaped.length >= 2) {
+      val first = unescaped.first()
+      val last = unescaped.last()
+      if ((first == '"' && last == '"') || (first == '\'' && last == '\'')) {
+        return unescaped.substring(1, unescaped.length - 1)
+      }
+    }
+    return unescaped
   }
 
   // ── 直接操作 API (コマンドから呼び出す) ─────────────────────
@@ -1934,11 +2052,14 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
       value: String
   ) {
     val actionType = type.uppercase()
+    val normalizedValue = normalizeTypedInput(value)
     addActionToSlot(
-        session, slot, GuiActionDef(actionType, GuiActionCatalog.params(actionType, value)))
+        session,
+        slot,
+        GuiActionDef(actionType, GuiActionCatalog.params(actionType, normalizedValue)))
     applyPdcToItem(session, slot)
     saveWorkingCopy(session)
-    msg(player, "&e[GuiMaker] &aslot $slot アクション追加: &f${type.uppercase()} $value")
+    msg(player, "&e[GuiMaker] &aslot $slot アクション追加: &f${type.uppercase()} $normalizedValue")
   }
 
   fun cmdClearActions(player: Player, session: GuiEditorSession, slot: Int) {
@@ -1997,6 +2118,7 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
     when (action.type) {
       "OPEN_MENU" -> openMenuPicker(player, session, slot, actionIndex)
       "OPEN_POPUP" -> openPopupPicker(player, session, slot, actionIndex)
+      "OPEN_SPECIAL" -> openSpecialMenuPicker(player, session, slot, actionIndex)
       "SOUND" -> {
         session.soundVolume = action.params["volume"]?.toFloatOrNull()?.coerceIn(0.0f, 4.0f) ?: 1.0f
         openSoundCategoryPicker(player, session, slot, actionIndex)
@@ -3423,6 +3545,15 @@ class GuiEditorEngine(private val plugin: OyasaiMenu) : Listener {
   }
 
   inner class MenuIdPickHolder(
+      val session: GuiEditorSession,
+      val canvasSlot: Int,
+      val actionIndex: Int?,
+      val slotToId: Map<Int, String>
+  ) : InventoryHolder {
+    override fun getInventory(): Inventory = Bukkit.createInventory(this, 54)
+  }
+
+  inner class SpecialMenuPickHolder(
       val session: GuiEditorSession,
       val canvasSlot: Int,
       val actionIndex: Int?,

--- a/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/guimaker/GuiEditorSession.kt
+++ b/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/guimaker/GuiEditorSession.kt
@@ -9,14 +9,24 @@ data class GuiSlotDef(
     var lore: MutableList<String> = mutableListOf(),
     var permission: String? = null,
     var enchanted: Boolean = false,
-    val actions: MutableList<GuiActionDef> = mutableListOf()
+    val actions: MutableList<GuiActionDef> = mutableListOf(),
+    val extras: MutableMap<String, String> = mutableMapOf()
 )
+
+enum class GuiEditableSurface {
+  NORMAL,
+  POPUP
+}
+
+data class PopupEditorMeta(var glass: String = "GRAY_STAINED_GLASS_PANE", var navActive: Int = -1)
 
 class GuiEditorSession(
     val menuId: String,
     var menuTitle: String = "&8メニュー",
     var menuSize: Int = 54
 ) {
+  var surface: GuiEditableSurface = GuiEditableSurface.NORMAL
+  var popupMeta: PopupEditorMeta? = null
   val slots: MutableMap<Int, GuiSlotDef> = mutableMapOf()
   var pendingInput: PendingInput? = null
   var canvasInventory: Inventory? = null
@@ -24,6 +34,9 @@ class GuiEditorSession(
   var soundVolume: Float = 1.0f
   var favRegistering: Boolean = false // お気に入り登録モード中
   var templateEditTarget: GuiTemplateEntry? = null
+
+  val displayId: String
+    get() = if (surface == GuiEditableSurface.POPUP) "popup/$menuId" else menuId
 }
 
 sealed class PendingInput(val slot: Int) {

--- a/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/guimaker/GuiEditorSession.kt
+++ b/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/guimaker/GuiEditorSession.kt
@@ -51,5 +51,7 @@ sealed class PendingInput(val slot: Int) {
   class ActionParam(slot: Int, val actionType: String, val actionIndex: Int? = null) :
       PendingInput(slot)
 
+  class ActionRawParams(slot: Int, val actionIndex: Int) : PendingInput(slot)
+
   class MenuTitle(val color: String = "") : PendingInput(-1)
 }

--- a/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/guimaker/GuiMakerCommand.kt
+++ b/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/guimaker/GuiMakerCommand.kt
@@ -16,7 +16,8 @@ class GuiMakerCommand(private val plugin: OyasaiMenu, private val engine: GuiEdi
     CommandExecutor, TabCompleter {
 
   companion object {
-    private val ROOT_SUBCOMMANDS = listOf("new", "edit", "list", "ui", "template", "help")
+    private val ROOT_SUBCOMMANDS =
+        listOf("hub", "new", "edit", "list", "popup", "special", "ui", "template", "help")
     private val EDIT_SUBCOMMANDS =
         listOf(
             "canvas",
@@ -34,6 +35,7 @@ class GuiMakerCommand(private val plugin: OyasaiMenu, private val engine: GuiEdi
             "clearactions",
             "clearslot")
     private val MENU_ID_PATTERN = Regex("[a-zA-Z0-9_.-]+(?:/[a-zA-Z0-9_.-]+)*")
+    private val POPUP_ID_PATTERN = Regex("[a-zA-Z0-9_.-]+")
   }
 
   override fun onCommand(
@@ -52,13 +54,16 @@ class GuiMakerCommand(private val plugin: OyasaiMenu, private val engine: GuiEdi
     }
 
     when (args.getOrNull(0)?.lowercase()) {
+      "hub" -> engine.openHub(sender)
       "new" -> handleNew(sender, args)
       "edit" -> handleEdit(sender, args)
       "list" -> handleList(sender)
+      "popup" -> handlePopup(sender, args)
+      "special" -> engine.openSpecialSurfaceHub(sender)
       "ui" -> handleUi(sender, args)
       "template" -> handleTemplate(sender, args)
-      "help",
-      null -> printHelp(sender)
+      "help" -> printHelp(sender)
+      null -> engine.openHub(sender)
       else -> printHelp(sender)
     }
     return true
@@ -95,6 +100,22 @@ class GuiMakerCommand(private val plugin: OyasaiMenu, private val engine: GuiEdi
         return engine.uiScreenNames().filter { it.startsWith(args[2], ignoreCase = true) }
       }
     }
+    if (args[0].equals("popup", ignoreCase = true)) {
+      if (args.size == 2)
+          return listOf("list", "edit", "new", "set").filter {
+            it.startsWith(args[1], ignoreCase = true)
+          }
+      if (args.size == 3 && args[1].equals("edit", ignoreCase = true)) {
+        return GuiMakerExporter.listPopupIds(plugin).filter {
+          it.startsWith(args[2], ignoreCase = true)
+        }
+      }
+      if (args.size == 4 && args[1].equals("set", ignoreCase = true)) {
+        return listOf("glass", "nav_active", "title").filter {
+          it.startsWith(args[3], ignoreCase = true)
+        }
+      }
+    }
     if (args[0].equals("template", ignoreCase = true)) {
       if (args.size == 2)
           return listOf("approve").filter { it.startsWith(args[1], ignoreCase = true) }
@@ -123,6 +144,89 @@ class GuiMakerCommand(private val plugin: OyasaiMenu, private val engine: GuiEdi
     val session = engine.newSession(sender, menuId)
     engine.openCanvas(sender, session)
     sender.sendMessage(comp("&e[GuiMaker] &a新規メニュー '&f$menuId&a' を作成しました。"))
+  }
+
+  private fun handlePopup(sender: Player, args: Array<String>) {
+    when (args.getOrNull(1)?.lowercase()) {
+      null,
+      "list" -> engine.openPopupMenuList(sender)
+      "edit" -> {
+        val popupId =
+            args.getOrNull(2)
+                ?: run {
+                  sender.sendMessage(comp("&c使用方法: /guimaker popup edit <popup-id>"))
+                  return
+                }
+        if (!validatePopupId(sender, popupId)) return
+        val session =
+            PopupMenuAdapter.load(plugin, popupId)
+                ?: run {
+                  sender.sendMessage(
+                      comp("&cPopup '$popupId' が見つかりません。新規作成は /guimaker popup new $popupId です。"))
+                  return
+                }
+        engine.sessions[sender.uniqueId] = session
+        engine.openCanvas(sender, session)
+        sender.sendMessage(comp("&e[GuiMaker] &aPopup '&f$popupId&a' を専用エディタで開きました。"))
+      }
+      "new" -> {
+        val popupId =
+            args.getOrNull(2)
+                ?: run {
+                  sender.sendMessage(comp("&c使用方法: /guimaker popup new <popup-id>"))
+                  return
+                }
+        if (!validatePopupId(sender, popupId)) return
+        val session = PopupMenuAdapter.newSession(plugin, popupId)
+        engine.sessions[sender.uniqueId] = session
+        engine.openCanvas(sender, session)
+        sender.sendMessage(comp("&e[GuiMaker] &a新規Popup '&f$popupId&a' を作成しました。"))
+      }
+      "set" -> handlePopupSet(sender, args)
+      else -> {
+        sender.sendMessage(comp("&e[GuiMaker] Popup編集"))
+        sender.sendMessage(comp("&7/guimaker popup list"))
+        sender.sendMessage(comp("&7/guimaker popup edit <id>"))
+        sender.sendMessage(comp("&7/guimaker popup new <id>"))
+        sender.sendMessage(comp("&7/guimaker popup set <id> glass|nav_active|title <value>"))
+      }
+    }
+  }
+
+  private fun handlePopupSet(sender: Player, args: Array<String>) {
+    val popupId =
+        args.getOrNull(2)
+            ?: run {
+              sender.sendMessage(
+                  comp("&c使用方法: /guimaker popup set <id> glass|nav_active|title <value>"))
+              return
+            }
+    if (!validatePopupId(sender, popupId)) return
+    val field = args.getOrNull(3)?.lowercase()
+    val value = args.drop(4).joinToString(" ")
+    if (field == null || value.isBlank()) {
+      sender.sendMessage(comp("&c使用方法: /guimaker popup set <id> glass|nav_active|title <value>"))
+      return
+    }
+    val session =
+        PopupMenuAdapter.load(plugin, popupId)
+            ?: run {
+              sender.sendMessage(comp("&cPopup '$popupId' が見つかりません。"))
+              return
+            }
+    val meta = session.popupMeta ?: PopupEditorMeta().also { session.popupMeta = it }
+    when (field) {
+      "glass" -> meta.glass = value.uppercase()
+      "nav_active" -> meta.navActive = value.toIntOrNull() ?: -1
+      "title" -> session.menuTitle = value
+      else -> {
+        sender.sendMessage(comp("&c不明なPopup設定です: &f$field"))
+        return
+      }
+    }
+    engine.sessions[sender.uniqueId] = session
+    GuiMakerExporter.exportDraft(plugin, session)
+    sender.sendMessage(comp("&e[GuiMaker] &aPopup設定をドラフト保存しました: &f${session.displayId}"))
   }
 
   private fun handleEdit(sender: Player, args: Array<String>) {
@@ -233,7 +337,7 @@ class GuiMakerCommand(private val plugin: OyasaiMenu, private val engine: GuiEdi
           return
         }
         val value = args.drop(5).joinToString(" ")
-        if (type != "CLOSE" && value.isBlank()) {
+        if (type !in setOf("CLOSE", "OPEN_SELL", "OPEN_MACRO") && value.isBlank()) {
           sender.sendMessage(comp("&c$type には値が必要です。"))
           return
         }
@@ -266,6 +370,7 @@ class GuiMakerCommand(private val plugin: OyasaiMenu, private val engine: GuiEdi
 
   private fun handleUi(sender: Player, args: Array<String>) {
     when (args.getOrNull(1)?.lowercase()) {
+      null -> engine.openUiScreenList(sender)
       "list" ->
           sender.sendMessage(
               comp("&e[GuiMaker] &f編集可能なUI画面: &a${engine.uiScreenNames().joinToString("&7, &a")}"))
@@ -302,6 +407,9 @@ class GuiMakerCommand(private val plugin: OyasaiMenu, private val engine: GuiEdi
 
   private fun handleTemplate(sender: Player, args: Array<String>) {
     when (args.getOrNull(1)?.lowercase()) {
+      null -> {
+        engine.openTemplateLibrary(sender)
+      }
       "approve" -> approveTemplate(sender, args)
       else -> {
         sender.sendMessage(comp("&e[GuiMaker] テンプレート管理"))
@@ -409,6 +517,12 @@ class GuiMakerCommand(private val plugin: OyasaiMenu, private val engine: GuiEdi
     return false
   }
 
+  private fun validatePopupId(sender: Player, popupId: String): Boolean {
+    val valid = popupId.matches(POPUP_ID_PATTERN)
+    if (!valid) sender.sendMessage(comp("&cPopup IDには英数字・_・-・. のみ使用できます。"))
+    return valid
+  }
+
   private fun resolveOwnerUuid(raw: String): UUID =
       runCatching { UUID.fromString(raw) }
           .getOrElse {
@@ -435,8 +549,12 @@ class GuiMakerCommand(private val plugin: OyasaiMenu, private val engine: GuiEdi
 
   private fun printHelp(sender: Player) {
     sender.sendMessage(comp("&e===== GuiMaker ====="))
+    sender.sendMessage(comp("&7/guimaker                                 &f- 編集ハブを開く"))
     sender.sendMessage(comp("&7/guimaker new <id>                         &f- 新規メニューを作成"))
     sender.sendMessage(comp("&7/guimaker edit <id> [canvas]               &f- 編集キャンバスを開く"))
+    sender.sendMessage(comp("&7/guimaker popup list|edit|new              &f- Popup専用エディタ"))
+    sender.sendMessage(comp("&7/guimaker ui                               &f- GUI Maker UI編集"))
+    sender.sendMessage(comp("&7/guimaker special                          &f- 特殊メニュー入口"))
     sender.sendMessage(comp("&7/guimaker edit <id> preview                &f- 現在の編集内容をプレビュー"))
     sender.sendMessage(comp("&7/guimaker edit <id> commit                 &f- OyasaiMenu に反映"))
     sender.sendMessage(comp("&7/guimaker edit <id> revert                 &f- ドラフトを破棄"))

--- a/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/guimaker/GuiMakerCommand.kt
+++ b/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/guimaker/GuiMakerCommand.kt
@@ -118,6 +118,7 @@ class GuiMakerCommand(private val plugin: OyasaiMenu, private val engine: GuiEdi
               return
             }
     if (!validateMenuId(sender, menuId)) return
+    if (!validateEditableMenuId(sender, menuId)) return
 
     val session = engine.newSession(sender, menuId)
     engine.openCanvas(sender, session)
@@ -132,6 +133,7 @@ class GuiMakerCommand(private val plugin: OyasaiMenu, private val engine: GuiEdi
               return
             }
     if (!validateMenuId(sender, menuId)) return
+    if (!validateEditableMenuId(sender, menuId)) return
 
     val operation = args.getOrNull(2)?.lowercase() ?: "canvas"
     val session =
@@ -398,6 +400,13 @@ class GuiMakerCommand(private val plugin: OyasaiMenu, private val engine: GuiEdi
       sender.sendMessage(comp("&cIDには英数字・_・-・. と階層用の / のみ使用できます。'.' または '..' 単独の階層は使えません。"))
     }
     return valid
+  }
+
+  private fun validateEditableMenuId(sender: Player, menuId: String): Boolean {
+    if (GuiMakerExporter.isEditableMenuId(menuId)) return true
+    sender.sendMessage(comp("&cこのIDは通常GUIメーカーの編集対象外です: &f$menuId"))
+    sender.sendMessage(comp("&7popup/* や shop/shops などは形式が違うため、専用エディタが必要です。"))
+    return false
   }
 
   private fun resolveOwnerUuid(raw: String): UUID =

--- a/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/guimaker/GuiMakerExporter.kt
+++ b/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/guimaker/GuiMakerExporter.kt
@@ -11,6 +11,8 @@ import org.bukkit.inventory.ItemStack
 
 object GuiMakerExporter {
 
+  private val blockedLiveFileNames = setOf("custom_items.yml", "shops.yml", "pointshop.yml")
+
   private fun draftFile(plugin: OyasaiMenu, menuId: String): File =
       File(plugin.dataFolder, "guimaker/$menuId.yml").also { it.parentFile.mkdirs() }
 
@@ -35,6 +37,7 @@ object GuiMakerExporter {
   }
 
   fun loadIntoSession(plugin: OyasaiMenu, session: GuiEditorSession): Boolean {
+    if (!isEditableMenuId(session.menuId)) return false
     val draft = draftFile(plugin, session.menuId)
     val live = liveFile(plugin, session.menuId)
     val file =
@@ -64,18 +67,29 @@ object GuiMakerExporter {
     if (draftDir.exists()) {
       draftDir
           .walkTopDown()
-          .filter { it.isFile && it.extension == "yml" }
-          .forEach { ids.add(it.toRelativeString(draftDir).removeSuffix(".yml")) }
+          .filter { it.isFile && it.extension.equals("yml", ignoreCase = true) }
+          .forEach {
+            val id = it.toRelativeString(draftDir).removeYamlSuffix()
+            if (isEditableMenuId(id)) ids.add(id)
+          }
     }
     val liveDir = File(plugin.dataFolder, "menus")
     if (liveDir.exists()) {
       liveDir
           .walkTopDown()
-          .filter { it.isFile && it.extension == "yml" }
-          .forEach { ids.add(it.toRelativeString(liveDir).removeSuffix(".yml")) }
+          .filter { isEditableLiveMenuFile(liveDir, it) }
+          .forEach {
+            val id = it.toRelativeString(liveDir).removeYamlSuffix()
+            if (isEditableMenuId(id)) ids.add(id)
+          }
     }
     return ids.sorted()
   }
+
+  fun isEditableMenuId(menuId: String): Boolean =
+      !menuId.startsWith("popup/") &&
+          menuId.split('/').none { it == "." || it == ".." } &&
+          "${menuId.substringAfterLast('/')}.yml".lowercase() !in blockedLiveFileNames
 
   // ── 内部処理 ──────────────────────────────────────────────
 
@@ -222,4 +236,14 @@ object GuiMakerExporter {
   }
 
   private fun rawMaterial(item: ItemStack): Material? = item.type.takeIf { it != Material.AIR }
+
+  private fun isEditableLiveMenuFile(liveDir: File, file: File): Boolean {
+    if (!file.isFile || !file.extension.equals("yml", ignoreCase = true)) return false
+    if (file.name.lowercase() in blockedLiveFileNames) return false
+    val relative = file.toRelativeString(liveDir)
+    return !relative.startsWith("popup${File.separator}") && !relative.startsWith("popup/")
+  }
+
+  private fun String.removeYamlSuffix(): String =
+      removeSuffix(".yml").removeSuffix(".YML").removeSuffix(".yaml").removeSuffix(".YAML")
 }

--- a/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/guimaker/GuiMakerExporter.kt
+++ b/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/guimaker/GuiMakerExporter.kt
@@ -1,6 +1,7 @@
 package com.github.sahyuya.oyasaiMenu.guimaker
 
 import com.github.sahyuya.oyasaiMenu.OyasaiMenu
+import com.github.sahyuya.oyasaiMenu.model.PopupActionType
 import com.github.sahyuya.oyasaiMenu.util.ItemVisuals
 import java.io.File
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer
@@ -16,24 +17,44 @@ object GuiMakerExporter {
   private fun draftFile(plugin: OyasaiMenu, menuId: String): File =
       File(plugin.dataFolder, "guimaker/$menuId.yml").also { it.parentFile.mkdirs() }
 
+  private fun popupDraftFile(plugin: OyasaiMenu, popupId: String): File =
+      File(plugin.dataFolder, "guimaker/popup/$popupId.yml").also { it.parentFile.mkdirs() }
+
   private fun liveFile(plugin: OyasaiMenu, menuId: String): File =
       File(plugin.dataFolder, "menus/$menuId.yml")
+
+  private fun popupLiveFile(plugin: OyasaiMenu, popupId: String): File =
+      File(plugin.dataFolder, "menus/popup/$popupId.yml")
+
+  private fun draftFile(plugin: OyasaiMenu, session: GuiEditorSession): File =
+      if (session.surface == GuiEditableSurface.POPUP) popupDraftFile(plugin, session.menuId)
+      else draftFile(plugin, session.menuId)
+
+  private fun liveFile(plugin: OyasaiMenu, session: GuiEditorSession): File =
+      if (session.surface == GuiEditableSurface.POPUP) popupLiveFile(plugin, session.menuId)
+      else liveFile(plugin, session.menuId)
 
   // ── 公開 API ──────────────────────────────────────────────
 
   fun exportDraft(plugin: OyasaiMenu, session: GuiEditorSession) {
-    runCatching { writeYaml(draftFile(plugin, session.menuId), session) }
+    runCatching { writeYaml(draftFile(plugin, session), session) }
         .onFailure { plugin.logger.warning("[GuiMaker] ドラフト保存失敗: ${it.message}") }
   }
 
   fun hasDraft(plugin: OyasaiMenu, menuId: String): Boolean = draftFile(plugin, menuId).exists()
 
+  fun hasDraft(plugin: OyasaiMenu, session: GuiEditorSession): Boolean =
+      draftFile(plugin, session).exists()
+
+  fun hasPopupDraft(plugin: OyasaiMenu, popupId: String): Boolean =
+      popupDraftFile(plugin, popupId).exists()
+
   fun commit(plugin: OyasaiMenu, session: GuiEditorSession): Result<String> = runCatching {
-    saveSessionToFile(plugin, session, liveFile(plugin, session.menuId))
+    saveSessionToFile(plugin, session, liveFile(plugin, session))
   }
 
   fun revertDraft(plugin: OyasaiMenu, session: GuiEditorSession) {
-    draftFile(plugin, session.menuId).delete()
+    draftFile(plugin, session).delete()
   }
 
   fun loadIntoSession(plugin: OyasaiMenu, session: GuiEditorSession): Boolean {
@@ -86,6 +107,47 @@ object GuiMakerExporter {
     return ids.sorted()
   }
 
+  fun listPopupIds(plugin: OyasaiMenu): List<String> {
+    val ids = mutableSetOf<String>()
+    val draftDir = File(plugin.dataFolder, "guimaker/popup")
+    if (draftDir.exists()) {
+      draftDir
+          .listFiles()
+          ?.filter { it.isFile && it.extension.equals("yml", ignoreCase = true) }
+          ?.forEach { ids.add(it.nameWithoutExtension) }
+    }
+    val liveDir = File(plugin.dataFolder, "menus/popup")
+    if (liveDir.exists()) {
+      liveDir
+          .listFiles()
+          ?.filter { it.isFile && it.extension.equals("yml", ignoreCase = true) }
+          ?.forEach { ids.add(it.nameWithoutExtension) }
+    }
+    plugin.popupMenuLoader.getPopupIds().forEach { ids.add(it) }
+    return ids.sorted()
+  }
+
+  fun newPopupSession(popupId: String): GuiEditorSession =
+      GuiEditorSession(popupId, "&8$popupId", 54).also {
+        it.surface = GuiEditableSurface.POPUP
+        it.popupMeta = PopupEditorMeta()
+        it.canvasInventory = Bukkit.createInventory(null, 54)
+      }
+
+  fun loadPopupIntoSession(plugin: OyasaiMenu, session: GuiEditorSession): Boolean {
+    session.surface = GuiEditableSurface.POPUP
+    val draft = popupDraftFile(plugin, session.menuId)
+    val live = popupLiveFile(plugin, session.menuId)
+    val file =
+        when {
+          draft.exists() -> draft
+          live.exists() -> live
+          else -> return false
+        }
+    parsePopupYamlIntoSession(plugin, file, session)
+    return true
+  }
+
   fun isEditableMenuId(menuId: String): Boolean =
       !menuId.startsWith("popup/") &&
           menuId.split('/').none { it == "." || it == ".." } &&
@@ -94,6 +156,10 @@ object GuiMakerExporter {
   // ── 内部処理 ──────────────────────────────────────────────
 
   private fun writeYaml(file: File, session: GuiEditorSession) {
+    if (session.surface == GuiEditableSurface.POPUP) {
+      writePopupYaml(file, session)
+      return
+    }
     val inv = session.canvasInventory ?: return
     val yaml = YamlConfiguration()
     yaml.set("menu.title", session.menuTitle)
@@ -139,6 +205,54 @@ object GuiMakerExporter {
               map
             }
         yaml.set("$key.actions", actionList)
+      }
+    }
+    yaml.save(file)
+  }
+
+  private fun writePopupYaml(file: File, session: GuiEditorSession) {
+    val inv = session.canvasInventory ?: return
+    val yaml = YamlConfiguration()
+    val meta = session.popupMeta ?: PopupEditorMeta()
+    yaml.set("title", session.menuTitle)
+    yaml.set("glass", meta.glass)
+    yaml.set("nav_active", meta.navActive)
+
+    val usedKeys = mutableSetOf<String>()
+    for (slot in 0 until inv.size) {
+      if (slot in 45..53) continue
+      val item = inv.getItem(slot)?.takeIf { it.type != Material.AIR } ?: continue
+      val def = session.slots[slot]
+      val key = uniquePopupKey(def?.extras?.get("popup.key"), slot, usedKeys)
+      val base = "items.$key"
+      val material = rawMaterial(item) ?: continue
+
+      yaml.set("$base.slot", slot)
+      yaml.set("$base.icon", popupMaterialName(material, def?.extras?.get("texture")))
+      def?.extras?.get("texture")?.takeIf { it.isNotBlank() }?.let { yaml.set("$base.texture", it) }
+      def?.name?.takeIf { it.isNotEmpty() }?.let { yaml.set("$base.name", it) }
+      def?.lore?.takeIf { it.isNotEmpty() }?.let { yaml.set("$base.lore", it.toList()) }
+      if (def?.enchanted == true) yaml.set("$base.enchanted", true)
+      def?.permission?.takeIf { it.isNotBlank() }?.let { yaml.set("$base.required_permission", it) }
+      if (def?.extras?.get("op_only")?.toBooleanStrictOrNull() == true) {
+        yaml.set("$base.op_only", true)
+      }
+      writeOptionalPopupString(yaml, base, def, "fallback_icon")
+      writeOptionalPopupString(yaml, base, def, "fallback_texture")
+      writeOptionalPopupString(yaml, base, def, "fallback_name")
+      def?.extras
+          ?.get("fallback_lore")
+          ?.lines()
+          ?.filter { it.isNotEmpty() }
+          ?.takeIf { it.isNotEmpty() }
+          ?.let { yaml.set("$base.fallback_lore", it) }
+
+      def?.actions
+          ?.takeIf { it.isNotEmpty() }
+          ?.let { yaml.set("$base.actions", it.mapNotNull { action -> popupActionMap(action) }) }
+      def?.extras?.get("fallback_actions")?.let { raw ->
+        val actions = deserializeActions(raw).mapNotNull { popupActionMap(it) }
+        if (actions.isNotEmpty()) yaml.set("$base.fallback_actions", actions)
       }
     }
     yaml.save(file)
@@ -228,6 +342,103 @@ object GuiMakerExporter {
             org.bukkit.NamespacedKey(plugin, "gm_actions"),
             org.bukkit.persistence.PersistentDataType.STRING,
             actStr)
+        pdc.set(
+            org.bukkit.NamespacedKey(plugin, "gm_extra"),
+            org.bukkit.persistence.PersistentDataType.STRING,
+            serializeExtras(def.extras))
+        item.itemMeta = meta
+      }
+      tempInv.setItem(slot, item)
+    }
+    session.canvasInventory = tempInv
+  }
+
+  private fun parsePopupYamlIntoSession(plugin: OyasaiMenu, file: File, session: GuiEditorSession) {
+    val yaml = YamlConfiguration.loadConfiguration(file)
+    session.surface = GuiEditableSurface.POPUP
+    session.menuTitle = yaml.getString("title", "&8${session.menuId}") ?: "&8${session.menuId}"
+    session.menuSize = 54
+    session.popupMeta =
+        PopupEditorMeta(
+            glass = yaml.getString("glass", "GRAY_STAINED_GLASS_PANE") ?: "GRAY_STAINED_GLASS_PANE",
+            navActive = yaml.getInt("nav_active", -1))
+    session.slots.clear()
+
+    val tempInv = Bukkit.createInventory(null, 54)
+    yaml.getConfigurationSection("items")?.getKeys(false)?.forEach { key ->
+      val sec = yaml.getConfigurationSection("items.$key") ?: return@forEach
+      val slot = sec.getInt("slot", 0).takeIf { it in 0..44 } ?: return@forEach
+      val iconName = sec.getString("icon", "STONE")?.uppercase() ?: "STONE"
+      val texture = sec.getString("texture")
+      val mat =
+          when {
+            iconName == "CUSTOM_HEAD" -> Material.PLAYER_HEAD
+            iconName == "AIR" -> Material.AIR
+            else -> runCatching { Material.valueOf(iconName) }.getOrElse { Material.STONE }
+          }
+      if (mat == Material.AIR) return@forEach
+
+      val def =
+          GuiSlotDef(
+              name = sec.getString("name", "") ?: "",
+              lore = sec.getStringList("lore").toMutableList(),
+              permission = sec.getString("required_permission"),
+              enchanted = sec.getBoolean("enchanted", false),
+              actions = parsePopupActions(sec.getList("actions")).toMutableList())
+      def.extras["popup.key"] = key
+      texture?.let { def.extras["texture"] = it }
+      if (sec.getBoolean("op_only", false)) def.extras["op_only"] = "true"
+      listOf("fallback_icon", "fallback_texture", "fallback_name").forEach { field ->
+        sec.getString(field)?.let { def.extras[field] = it }
+      }
+      val fallbackLore = sec.getStringList("fallback_lore")
+      if (fallbackLore.isNotEmpty()) def.extras["fallback_lore"] = fallbackLore.joinToString("\n")
+      val fallbackActions = parsePopupActions(sec.getList("fallback_actions"))
+      if (fallbackActions.isNotEmpty())
+          def.extras["fallback_actions"] = serializeActions(fallbackActions)
+
+      session.slots[slot] = def
+      val item = ItemStack(mat)
+      val meta = item.itemMeta
+      if (meta != null) {
+        if (def.name.isNotEmpty())
+            meta.displayName(
+                LegacyComponentSerializer.legacyAmpersand()
+                    .deserialize(def.name)
+                    .decoration(net.kyori.adventure.text.format.TextDecoration.ITALIC, false))
+        if (def.lore.isNotEmpty())
+            meta.lore(
+                def.lore.map {
+                  LegacyComponentSerializer.legacyAmpersand()
+                      .deserialize(it)
+                      .decoration(net.kyori.adventure.text.format.TextDecoration.ITALIC, false)
+                })
+        ItemVisuals.applyEnchantVisual(meta, def.enchanted)
+        val pdc = meta.persistentDataContainer
+        pdc.set(
+            org.bukkit.NamespacedKey(plugin, "gm_name"),
+            org.bukkit.persistence.PersistentDataType.STRING,
+            def.name)
+        pdc.set(
+            org.bukkit.NamespacedKey(plugin, "gm_lore"),
+            org.bukkit.persistence.PersistentDataType.STRING,
+            def.lore.joinToString("\n"))
+        pdc.set(
+            org.bukkit.NamespacedKey(plugin, "gm_perm"),
+            org.bukkit.persistence.PersistentDataType.STRING,
+            def.permission ?: "")
+        pdc.set(
+            org.bukkit.NamespacedKey(plugin, "gm_enchanted"),
+            org.bukkit.persistence.PersistentDataType.STRING,
+            if (def.enchanted) "1" else "")
+        pdc.set(
+            org.bukkit.NamespacedKey(plugin, "gm_actions"),
+            org.bukkit.persistence.PersistentDataType.STRING,
+            serializeActions(def.actions))
+        pdc.set(
+            org.bukkit.NamespacedKey(plugin, "gm_extra"),
+            org.bukkit.persistence.PersistentDataType.STRING,
+            serializeExtras(def.extras))
         item.itemMeta = meta
       }
       tempInv.setItem(slot, item)
@@ -236,6 +447,127 @@ object GuiMakerExporter {
   }
 
   private fun rawMaterial(item: ItemStack): Material? = item.type.takeIf { it != Material.AIR }
+
+  private fun popupMaterialName(material: Material, texture: String?): String =
+      if (material == Material.PLAYER_HEAD && !texture.isNullOrBlank()) "CUSTOM_HEAD"
+      else material.name
+
+  private fun writeOptionalPopupString(
+      yaml: YamlConfiguration,
+      base: String,
+      def: GuiSlotDef?,
+      field: String
+  ) {
+    def?.extras?.get(field)?.takeIf { it.isNotBlank() }?.let { yaml.set("$base.$field", it) }
+  }
+
+  private fun uniquePopupKey(preferred: String?, slot: Int, usedKeys: MutableSet<String>): String {
+    val base =
+        preferred?.takeIf { it.matches(Regex("[a-zA-Z0-9_.-]+")) }?.ifBlank { null } ?: "item_$slot"
+    if (usedKeys.add(base)) return base
+    var i = 2
+    while (!usedKeys.add("${base}_$i")) i++
+    return "${base}_$i"
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  private fun parsePopupActions(raw: List<*>?): List<GuiActionDef> =
+      (raw ?: emptyList<Any>()).filterIsInstance<Map<String, Any>>().mapNotNull { map ->
+        when {
+          map.containsKey("player_cmd") ->
+              GuiActionDef("PLAYER_CMD", mapOf("command" to map["player_cmd"].toString()))
+          map.containsKey("console_cmd") ->
+              GuiActionDef("CONSOLE_CMD", mapOf("command" to map["console_cmd"].toString()))
+          map.containsKey("op_player_cmd") ->
+              GuiActionDef("OP_PLAYER_CMD", mapOf("command" to map["op_player_cmd"].toString()))
+          map.containsKey("url") -> GuiActionDef("URL", mapOf("url" to map["url"].toString()))
+          map.containsKey("chat_paste") ->
+              GuiActionDef("CHAT_PASTE", mapOf("text" to map["chat_paste"].toString()))
+          map.containsKey("suggest_command") ->
+              GuiActionDef("SUGGEST_COMMAND", mapOf("command" to map["suggest_command"].toString()))
+          map.containsKey("open_popup") ->
+              GuiActionDef("OPEN_POPUP", mapOf("target" to map["open_popup"].toString()))
+          map.containsKey("open_special") ->
+              GuiActionDef("OPEN_SPECIAL", mapOf("target" to map["open_special"].toString()))
+          map.containsKey("open_shop") ->
+              GuiActionDef("OPEN_SHOP", mapOf("category" to map["open_shop"].toString()))
+          map.containsKey("open_sell") -> GuiActionDef("OPEN_SELL")
+          map.containsKey("open_macro") -> GuiActionDef("OPEN_MACRO")
+          map.containsKey("open_point_shop") ->
+              GuiActionDef(
+                  "OPEN_POINT_SHOP", mapOf("category" to map["open_point_shop"].toString()))
+          map.containsKey("open_menu") ->
+              GuiActionDef("OPEN_MENU", mapOf("target" to map["open_menu"].toString()))
+          map.containsKey("close") -> GuiActionDef("CLOSE")
+          else -> null
+        }
+      }
+
+  private fun popupActionMap(action: GuiActionDef): Map<String, Any>? =
+      when (runCatching { PopupActionType.valueOf(action.type) }.getOrNull()) {
+        PopupActionType.PLAYER_CMD -> mapOf("player_cmd" to action.popupCommandValue())
+        PopupActionType.CONSOLE_CMD -> mapOf("console_cmd" to action.popupCommandValue())
+        PopupActionType.OP_PLAYER_CMD -> mapOf("op_player_cmd" to action.popupCommandValue())
+        PopupActionType.URL ->
+            mapOf("url" to (action.params["url"] ?: action.params["value"] ?: ""))
+        PopupActionType.CHAT_PASTE ->
+            mapOf("chat_paste" to (action.params["text"] ?: action.params["value"] ?: ""))
+        PopupActionType.SUGGEST_COMMAND -> mapOf("suggest_command" to action.popupCommandValue())
+        PopupActionType.OPEN_POPUP -> mapOf("open_popup" to action.popupTargetValue())
+        PopupActionType.OPEN_SPECIAL -> mapOf("open_special" to action.popupTargetValue())
+        PopupActionType.OPEN_SHOP ->
+            mapOf("open_shop" to (action.params["category"] ?: action.popupTargetValue()))
+        PopupActionType.OPEN_SELL -> mapOf("open_sell" to true)
+        PopupActionType.OPEN_MACRO -> mapOf("open_macro" to true)
+        PopupActionType.OPEN_POINT_SHOP ->
+            mapOf("open_point_shop" to (action.params["category"] ?: action.popupTargetValue()))
+        PopupActionType.OPEN_MENU -> mapOf("open_menu" to action.popupTargetValue())
+        PopupActionType.CLOSE -> mapOf("close" to true)
+        null -> null
+      }
+
+  private fun GuiActionDef.popupCommandValue(): String =
+      params["command"] ?: params["value"] ?: params["text"] ?: ""
+
+  private fun GuiActionDef.popupTargetValue(): String =
+      params["target"] ?: params["value"] ?: params["category"] ?: ""
+
+  private fun serializeActions(actions: List<GuiActionDef>): String =
+      actions.joinToString("\n") { a ->
+        a.type +
+            if (a.params.isEmpty()) ""
+            else
+                " " +
+                    a.params.entries.joinToString(" ") { (key, value) ->
+                      "$key=${value.replace(" ", "\\s").replace("\n", "\\n")}"
+                    }
+      }
+
+  private fun deserializeActions(raw: String): List<GuiActionDef> {
+    if (raw.isBlank()) return emptyList()
+    return raw.lines().mapNotNull { line ->
+      val parts = line.trim().split(" ")
+      if (parts.isEmpty() || parts[0].isBlank()) return@mapNotNull null
+      val type = parts[0]
+      val params =
+          parts
+              .drop(1)
+              .mapNotNull { kv ->
+                val eq = kv.indexOf('=')
+                if (eq < 0) null
+                else
+                    kv.substring(0, eq) to
+                        kv.substring(eq + 1).replace("\\s", " ").replace("\\n", "\n")
+              }
+              .toMap()
+      GuiActionDef(type, params)
+    }
+  }
+
+  private fun serializeExtras(extras: Map<String, String>): String =
+      extras.entries.joinToString("\n") { (key, value) ->
+        "$key=${value.replace(" ", "\\s").replace("\n", "\\n")}"
+      }
 
   private fun isEditableLiveMenuFile(liveDir: File, file: File): Boolean {
     if (!file.isFile || !file.extension.equals("yml", ignoreCase = true)) return false

--- a/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/guimaker/GuiMakerExporter.kt
+++ b/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/guimaker/GuiMakerExporter.kt
@@ -1,7 +1,9 @@
 package com.github.sahyuya.oyasaiMenu.guimaker
 
 import com.github.sahyuya.oyasaiMenu.OyasaiMenu
+import com.github.sahyuya.oyasaiMenu.model.PopupAction
 import com.github.sahyuya.oyasaiMenu.model.PopupActionType
+import com.github.sahyuya.oyasaiMenu.model.PopupMenuDef
 import com.github.sahyuya.oyasaiMenu.util.ItemVisuals
 import java.io.File
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer
@@ -142,7 +144,11 @@ object GuiMakerExporter {
         when {
           draft.exists() -> draft
           live.exists() -> live
-          else -> return false
+          else -> {
+            val loaded = plugin.popupMenuLoader.getPopup(session.menuId) ?: return false
+            parseLoadedPopupIntoSession(plugin, loaded, session)
+            return true
+          }
         }
     parsePopupYamlIntoSession(plugin, file, session)
     return true
@@ -444,6 +450,124 @@ object GuiMakerExporter {
       tempInv.setItem(slot, item)
     }
     session.canvasInventory = tempInv
+  }
+
+  private fun parseLoadedPopupIntoSession(
+      plugin: OyasaiMenu,
+      popup: PopupMenuDef,
+      session: GuiEditorSession
+  ) {
+    session.surface = GuiEditableSurface.POPUP
+    session.menuTitle = popup.title
+    session.menuSize = 54
+    session.popupMeta = PopupEditorMeta(glass = popup.glass.name, navActive = popup.navActive)
+    session.slots.clear()
+
+    val tempInv = Bukkit.createInventory(null, 54)
+    popup.items.forEach { popupItem ->
+      val slot = popupItem.slot.takeIf { it in 0..44 } ?: return@forEach
+      if (popupItem.icon == Material.AIR) return@forEach
+      val def =
+          GuiSlotDef(
+              name = popupItem.name,
+              lore = popupItem.lore.toMutableList(),
+              permission = popupItem.requiredPermission,
+              enchanted = popupItem.enchanted,
+              actions = popupItem.actions.map { popupActionDef(it) }.toMutableList())
+      def.extras["popup.key"] = popupItem.key
+      popupItem.customTexture?.let { def.extras["texture"] = it }
+      if (popupItem.opOnly) def.extras["op_only"] = "true"
+      popupItem.fallbackIcon?.let {
+        def.extras["fallback_icon"] = popupMaterialName(it, popupItem.fallbackTexture)
+      }
+      popupItem.fallbackTexture?.let { def.extras["fallback_texture"] = it }
+      popupItem.fallbackName.takeIf { it.isNotBlank() }?.let { def.extras["fallback_name"] = it }
+      if (popupItem.fallbackLore.isNotEmpty()) {
+        def.extras["fallback_lore"] = popupItem.fallbackLore.joinToString("\n")
+      }
+      if (popupItem.fallbackActions.isNotEmpty()) {
+        def.extras["fallback_actions"] =
+            serializeActions(popupItem.fallbackActions.map { popupActionDef(it) })
+      }
+      session.slots[slot] = def
+      setSessionItem(plugin, tempInv, slot, popupItem.icon, def)
+    }
+    session.canvasInventory = tempInv
+  }
+
+  private fun popupActionDef(action: PopupAction): GuiActionDef =
+      when (action.type) {
+        PopupActionType.PLAYER_CMD -> GuiActionDef("PLAYER_CMD", mapOf("command" to action.value))
+        PopupActionType.CONSOLE_CMD -> GuiActionDef("CONSOLE_CMD", mapOf("command" to action.value))
+        PopupActionType.OP_PLAYER_CMD ->
+            GuiActionDef("OP_PLAYER_CMD", mapOf("command" to action.value))
+        PopupActionType.URL -> GuiActionDef("URL", mapOf("url" to action.value))
+        PopupActionType.CHAT_PASTE -> GuiActionDef("CHAT_PASTE", mapOf("text" to action.value))
+        PopupActionType.SUGGEST_COMMAND ->
+            GuiActionDef("SUGGEST_COMMAND", mapOf("command" to action.value))
+        PopupActionType.OPEN_POPUP -> GuiActionDef("OPEN_POPUP", mapOf("target" to action.value))
+        PopupActionType.OPEN_SPECIAL ->
+            GuiActionDef("OPEN_SPECIAL", mapOf("target" to action.value))
+        PopupActionType.OPEN_SHOP -> GuiActionDef("OPEN_SHOP", mapOf("category" to action.value))
+        PopupActionType.OPEN_SELL -> GuiActionDef("OPEN_SELL")
+        PopupActionType.OPEN_MACRO -> GuiActionDef("OPEN_MACRO")
+        PopupActionType.OPEN_POINT_SHOP ->
+            GuiActionDef("OPEN_POINT_SHOP", mapOf("category" to action.value))
+        PopupActionType.OPEN_MENU -> GuiActionDef("OPEN_MENU", mapOf("target" to action.value))
+        PopupActionType.CLOSE -> GuiActionDef("CLOSE")
+      }
+
+  private fun setSessionItem(
+      plugin: OyasaiMenu,
+      inv: org.bukkit.inventory.Inventory,
+      slot: Int,
+      mat: Material,
+      def: GuiSlotDef
+  ) {
+    val item = ItemStack(mat)
+    val meta = item.itemMeta
+    if (meta != null) {
+      if (def.name.isNotEmpty())
+          meta.displayName(
+              LegacyComponentSerializer.legacyAmpersand()
+                  .deserialize(def.name)
+                  .decoration(net.kyori.adventure.text.format.TextDecoration.ITALIC, false))
+      if (def.lore.isNotEmpty())
+          meta.lore(
+              def.lore.map {
+                LegacyComponentSerializer.legacyAmpersand()
+                    .deserialize(it)
+                    .decoration(net.kyori.adventure.text.format.TextDecoration.ITALIC, false)
+              })
+      ItemVisuals.applyEnchantVisual(meta, def.enchanted)
+      val pdc = meta.persistentDataContainer
+      pdc.set(
+          org.bukkit.NamespacedKey(plugin, "gm_name"),
+          org.bukkit.persistence.PersistentDataType.STRING,
+          def.name)
+      pdc.set(
+          org.bukkit.NamespacedKey(plugin, "gm_lore"),
+          org.bukkit.persistence.PersistentDataType.STRING,
+          def.lore.joinToString("\n"))
+      pdc.set(
+          org.bukkit.NamespacedKey(plugin, "gm_perm"),
+          org.bukkit.persistence.PersistentDataType.STRING,
+          def.permission ?: "")
+      pdc.set(
+          org.bukkit.NamespacedKey(plugin, "gm_enchanted"),
+          org.bukkit.persistence.PersistentDataType.STRING,
+          if (def.enchanted) "1" else "")
+      pdc.set(
+          org.bukkit.NamespacedKey(plugin, "gm_actions"),
+          org.bukkit.persistence.PersistentDataType.STRING,
+          serializeActions(def.actions))
+      pdc.set(
+          org.bukkit.NamespacedKey(plugin, "gm_extra"),
+          org.bukkit.persistence.PersistentDataType.STRING,
+          serializeExtras(def.extras))
+      item.itemMeta = meta
+    }
+    inv.setItem(slot, item)
   }
 
   private fun rawMaterial(item: ItemStack): Material? = item.type.takeIf { it != Material.AIR }

--- a/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/guimaker/GuiTemplateStore.kt
+++ b/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/guimaker/GuiTemplateStore.kt
@@ -8,6 +8,7 @@ import java.nio.file.StandardCopyOption
 import java.util.UUID
 import net.kyori.adventure.text.format.TextDecoration
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer
+import org.bukkit.Bukkit
 import org.bukkit.Material
 import org.bukkit.configuration.ConfigurationSection
 import org.bukkit.configuration.file.YamlConfiguration
@@ -111,6 +112,27 @@ object GuiTemplateStore {
     val path = entry.file.relativeTo(plugin.dataFolder.parentFile).path
     require(entry.file.delete()) { "テンプレートを削除できませんでした: ${entry.id}" }
     path
+  }
+
+  fun ensureSharedBlockTemplate(
+      plugin: OyasaiMenu,
+      id: String,
+      material: Material,
+      def: GuiSlotDef
+  ): Result<String> = runCatching {
+    val safeId = sanitizeId(id)
+    val file = sharedFile(plugin, GuiTemplateKind.BLOCK, safeId)
+    if (file.exists()) return@runCatching file.relativeTo(plugin.dataFolder.parentFile).path
+    val session = GuiEditorSession("official/$safeId", "&8公式ブロック", 54)
+    val inv = Bukkit.createInventory(null, 54)
+    inv.setItem(0, buildBlockItem(material, def))
+    session.canvasInventory = inv
+    session.slots[0] =
+        def.copy(
+            lore = def.lore.toMutableList(),
+            actions = def.actions.toMutableList(),
+            extras = def.extras.toMutableMap())
+    saveBlockTemplateToFile(plugin, file, session, 0, inv.getItem(0) ?: ItemStack(material))
   }
 
   fun listTemplates(plugin: OyasaiMenu, player: Player): List<GuiTemplateEntry> =

--- a/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/loader/MenuLoader.kt
+++ b/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/loader/MenuLoader.kt
@@ -12,7 +12,7 @@ import org.bukkit.configuration.file.YamlConfiguration
  *
  * 変更点:
  * - テンプレート機能 (templates.yml / extends キー) を完全削除 templates.yml は不要になったため安全に削除可能
- * - root.yml をスキャン対象から除外 root メニューは MenuEngine の rootFallback で処理するため不要 root.yml ファイルは安全に削除可能
+ * - root.yml も通常メニューとしてロードする。初回起動時は同梱の menus/root.yml を展開する
  * - icon: CUSTOM_HEAD → Material.PLAYER_HEAD + customTexture 保持
  * - icon: AIR → Material.AIR として保持 (MenuEngine 側でスキップ)
  */
@@ -28,6 +28,7 @@ class MenuLoader(private val plugin: OyasaiMenu) {
       menusDir.mkdirs()
       plugin.logger.info("menus/ を作成しました。")
     }
+    ensureBundledMenu(menusDir, "root.yml")
     scanDirectory(menusDir, "", setOf("custom_items.yml", "shops.yml", "pointshop.yml"))
     plugin.logger.info("${menus.size} 個のメニューをロードしました。")
   }
@@ -36,6 +37,21 @@ class MenuLoader(private val plugin: OyasaiMenu) {
 
   fun getMenuCount(): Int = menus.size
 
+  private fun ensureBundledMenu(menusDir: File, fileName: String) {
+    val requestedId = fileName.substringBeforeLast(".")
+    val existing =
+        menusDir.listFiles()?.any {
+          it.isFile &&
+              it.nameWithoutExtension.equals(requestedId, ignoreCase = true) &&
+              it.extension.equals("yml", ignoreCase = true)
+        } == true
+    if (existing) return
+    val target = File(menusDir, fileName)
+    if (target.exists()) return
+    runCatching { plugin.saveResource("menus/$fileName", false) }
+        .onFailure { plugin.logger.warning("menus/$fileName の展開失敗。手動で配置してください。") }
+  }
+
   private fun scanDirectory(dir: File, prefix: String, skipFiles: Set<String> = emptySet()) {
     dir.listFiles()
         ?.sortedBy { it.name }
@@ -43,8 +59,13 @@ class MenuLoader(private val plugin: OyasaiMenu) {
           if (file.isDirectory) {
             if (file.name == "popup") return@forEach
             scanDirectory(file, "$prefix${file.name}/", skipFiles)
-          } else if (file.extension == "yml" && file.name !in skipFiles) {
-            val menuId = "$prefix${file.nameWithoutExtension}"
+          } else if (file.extension.equals("yml", ignoreCase = true) &&
+              file.name.lowercase() !in skipFiles) {
+            val id =
+                if (prefix.isEmpty() && file.nameWithoutExtension.equals("root", ignoreCase = true))
+                    "root"
+                else file.nameWithoutExtension
+            val menuId = "$prefix$id"
             runCatching { menus[menuId] = loadMenuFile(file, menuId) }
                 .onFailure { plugin.logger.warning("メニューロード失敗: $menuId → ${it.message}") }
           }

--- a/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/loader/PopupMenuLoader.kt
+++ b/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/loader/PopupMenuLoader.kt
@@ -234,6 +234,8 @@ class PopupMenuLoader(private val plugin: OyasaiMenu) {
             PopupAction(PopupActionType.SUGGEST_COMMAND, map["suggest_command"].toString())
         map.containsKey("open_popup") ->
             PopupAction(PopupActionType.OPEN_POPUP, map["open_popup"].toString())
+        map.containsKey("open_special") ->
+            PopupAction(PopupActionType.OPEN_SPECIAL, map["open_special"].toString())
         map.containsKey("open_shop") ->
             PopupAction(PopupActionType.OPEN_SHOP, map["open_shop"].toString())
         map.containsKey("open_sell") -> PopupAction(PopupActionType.OPEN_SELL, "")

--- a/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/model/Models.kt
+++ b/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/model/Models.kt
@@ -27,8 +27,10 @@ data class MenuItemDefinition(
 enum class ActionType {
   OPEN_MENU,
   OPEN_POPUP,
+  OPEN_SPECIAL,
   RUN_COMMAND,
   RUN_PLAYER_COMMAND,
+  PARAM_COMMAND,
   CONSOLE_CMD,
   PLAYER_CMD,
   OP_PLAYER_CMD,

--- a/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/model/PopupMenuModels.kt
+++ b/plugins/OyasaiMenu/src/main/kotlin/com/github/sahyuya/oyasaiMenu/model/PopupMenuModels.kt
@@ -63,6 +63,7 @@ enum class PopupActionType {
   CHAT_PASTE,
   SUGGEST_COMMAND,
   OPEN_POPUP,
+  OPEN_SPECIAL,
   OPEN_SHOP,
   OPEN_SELL,
   OPEN_MACRO,

--- a/plugins/OyasaiMenu/src/main/resources/announcements.yml
+++ b/plugins/OyasaiMenu/src/main/resources/announcements.yml
@@ -1,5 +1,5 @@
 # announcements.yml
-# 総合メニュー (root) の上部エリア (スロット 0〜44) に表示するお知らせ。
+# menus/root.yml の %announcement_title% / %announcement_body% に差し込まれるお知らせ。
 # title: アイテム表示名 (&カラーコード対応)
 # body:  Lore テキスト行 (リスト形式)
 

--- a/plugins/OyasaiMenu/src/main/resources/gui-maker-ui-screens.yml
+++ b/plugins/OyasaiMenu/src/main/resources/gui-maker-ui-screens.yml
@@ -19,17 +19,17 @@ screens:
     slots:
       4: {label: "編集対象", material: ENDER_CHEST}
       44: {label: "新規作成", material: WRITABLE_BOOK}
-      45: {label: "編集ハブへ戻る", material: ARROW}
       48: {label: "前のページ", material: ARROW}
       50: {label: "次のページ", material: ARROW}
+      53: {label: "編集ハブへ戻る", material: ARROW}
 
   ui_screen_list:
     default-glass: YELLOW_STAINED_GLASS_PANE
     slots:
       4: {label: "GUI Maker UI", material: ITEM_FRAME}
-      45: {label: "編集ハブへ戻る", material: ARROW}
       48: {label: "前のページ", material: ARROW}
       50: {label: "次のページ", material: ARROW}
+      53: {label: "編集ハブへ戻る", material: ARROW}
 
   special_surface:
     default-glass: LIGHT_BLUE_STAINED_GLASS_PANE
@@ -38,7 +38,7 @@ screens:
       13: {label: "確認ボタンメニュー", material: LIME_CONCRETE}
       15: {label: "可変コマンドメニュー", material: REPEATER}
       31: {label: "通常GUIへ配置", material: ENDER_CHEST}
-      45: {label: "編集ハブへ戻る", material: ARROW}
+      53: {label: "編集ハブへ戻る", material: ARROW}
 
   popup_settings:
     default-glass: PURPLE_STAINED_GLASS_PANE
@@ -48,7 +48,6 @@ screens:
       12: {label: "Nav Active -", material: ARROW}
       14: {label: "Nav Active +", material: ARROW}
       20: {label: "タイトル", material: NAME_TAG}
-      45: {label: "キャンバスへ戻る", material: ARROW}
       48: {label: "反映", material: LIME_CONCRETE_POWDER}
       53: {label: "キャンバスへ戻る", material: ARROW}
 
@@ -113,6 +112,7 @@ screens:
       12: {label: "上へ移動", material: ARROW}
       14: {label: "下へ移動", material: ARROW}
       22: {label: "現在の値", material: BOOK}
+      31: {label: "詳細パラメータを編集", material: WRITABLE_BOOK}
       37: {label: "アクションを追加", material: COMMAND_BLOCK}
       43: {label: "このアクションを削除", material: BARRIER}
 

--- a/plugins/OyasaiMenu/src/main/resources/gui-maker-ui-screens.yml
+++ b/plugins/OyasaiMenu/src/main/resources/gui-maker-ui-screens.yml
@@ -3,6 +3,55 @@ fallback-glass: GRAY_STAINED_GLASS_PANE
 restore-slots: [47, 48, 50, 51]
 
 screens:
+  hub:
+    default-glass: GRAY_STAINED_GLASS_PANE
+    slots:
+      10: {label: "通常GUI", material: ENDER_CHEST}
+      12: {label: "Popupメニュー", material: CHORUS_FRUIT}
+      14: {label: "特殊メニュー", material: ENDER_EYE}
+      16: {label: "GUI Maker UI", material: ITEM_FRAME}
+      31: {label: "テンプレート / 公式ブロック", material: NETHER_STAR}
+      49: {label: "ヘルプ", material: BOOK}
+      53: {label: "閉じる", material: BARRIER}
+
+  surface_list:
+    default-glass: LIME_STAINED_GLASS_PANE
+    slots:
+      4: {label: "編集対象", material: ENDER_CHEST}
+      44: {label: "新規作成", material: WRITABLE_BOOK}
+      45: {label: "編集ハブへ戻る", material: ARROW}
+      48: {label: "前のページ", material: ARROW}
+      50: {label: "次のページ", material: ARROW}
+
+  ui_screen_list:
+    default-glass: YELLOW_STAINED_GLASS_PANE
+    slots:
+      4: {label: "GUI Maker UI", material: ITEM_FRAME}
+      45: {label: "編集ハブへ戻る", material: ARROW}
+      48: {label: "前のページ", material: ARROW}
+      50: {label: "次のページ", material: ARROW}
+
+  special_surface:
+    default-glass: LIGHT_BLUE_STAINED_GLASS_PANE
+    slots:
+      11: {label: "オンラインプレイヤー一覧", material: PLAYER_HEAD}
+      13: {label: "確認ボタンメニュー", material: LIME_CONCRETE}
+      15: {label: "可変コマンドメニュー", material: REPEATER}
+      31: {label: "通常GUIへ配置", material: ENDER_CHEST}
+      45: {label: "編集ハブへ戻る", material: ARROW}
+
+  popup_settings:
+    default-glass: PURPLE_STAINED_GLASS_PANE
+    slots:
+      4: {label: "Popup専用設定", material: CHORUS_FRUIT}
+      10: {label: "背景ガラス", material: GRAY_STAINED_GLASS_PANE}
+      12: {label: "Nav Active -", material: ARROW}
+      14: {label: "Nav Active +", material: ARROW}
+      20: {label: "タイトル", material: NAME_TAG}
+      45: {label: "キャンバスへ戻る", material: ARROW}
+      48: {label: "反映", material: LIME_CONCRETE_POWDER}
+      53: {label: "キャンバスへ戻る", material: ARROW}
+
   context:
     default-glass: BLUE_STAINED_GLASS_PANE
     slots:
@@ -31,6 +80,9 @@ screens:
       11: {label: "ポップアップ", material: CHORUS_FRUIT}
       12: {label: "メニューを閉じる", material: OAK_DOOR}
       13: {label: "特殊メニュー", material: ENDER_EYE}
+      14: {label: "ショップ", material: CHEST}
+      15: {label: "ポイントショップ", material: NETHER_STAR}
+      16: {label: "一括売却", material: GOLD_INGOT}
       18: {label: "コマンド系カテゴリ", material: COMMAND_BLOCK}
       19: {label: "プレイヤーコマンド", material: COMMAND_BLOCK}
       20: {label: "コンソールコマンド", material: COMPARATOR}

--- a/plugins/OyasaiMenu/src/main/resources/gui-maker-ui-screens.yml
+++ b/plugins/OyasaiMenu/src/main/resources/gui-maker-ui-screens.yml
@@ -30,11 +30,13 @@ screens:
       10: {label: "メニューを開く", material: ENDER_CHEST}
       11: {label: "ポップアップ", material: CHORUS_FRUIT}
       12: {label: "メニューを閉じる", material: OAK_DOOR}
+      13: {label: "特殊メニュー", material: ENDER_EYE}
       18: {label: "コマンド系カテゴリ", material: COMMAND_BLOCK}
       19: {label: "プレイヤーコマンド", material: COMMAND_BLOCK}
       20: {label: "コンソールコマンド", material: COMPARATOR}
       21: {label: "OPコマンド", material: NETHER_STAR}
       22: {label: "コマンドを提案", material: BOOK}
+      23: {label: "可変コマンド", material: REPEATER}
       27: {label: "メッセージ系カテゴリ", material: PAPER}
       28: {label: "メッセージ送信", material: PAPER}
       29: {label: "ブロードキャスト", material: BEACON}
@@ -165,6 +167,15 @@ screens:
     slots:
       0: {label: "通常メニュー (情報)", material: ENDER_CHEST}
       4: {label: "アイテムプレビュー", material: ITEM_FRAME}
+      44: {label: "IDを手入力", material: WRITABLE_BOOK}
+
+  special_pick:
+    default-glass: LIGHT_BLUE_STAINED_GLASS_PANE
+    slots:
+      0: {label: "特殊メニュー (情報)", material: ENDER_EYE}
+      4: {label: "アイテムプレビュー", material: ITEM_FRAME}
+      20: {label: "オンラインプレイヤー", material: PLAYER_HEAD}
+      24: {label: "確認メニュー", material: LIME_CONCRETE}
       44: {label: "IDを手入力", material: WRITABLE_BOOK}
 
   favorites:

--- a/plugins/OyasaiMenu/src/main/resources/menus/root.yml
+++ b/plugins/OyasaiMenu/src/main/resources/menus/root.yml
@@ -1,0 +1,311 @@
+# Root menu. This file is intentionally editable by /guimaker edit root.
+menu:
+  title: "&8✦ おやさい鯖 メニュー ✦"
+  size: 54
+
+items:
+  welcome_00:
+    slot: 0
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_01:
+    slot: 1
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_02:
+    slot: 2
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_03:
+    slot: 3
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_04:
+    slot: 4
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_05:
+    slot: 5
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_06:
+    slot: 6
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_07:
+    slot: 7
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_08:
+    slot: 8
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_09:
+    slot: 9
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_10:
+    slot: 10
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_11:
+    slot: 11
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_12:
+    slot: 12
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_13:
+    slot: 13
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_14:
+    slot: 14
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_15:
+    slot: 15
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_16:
+    slot: 16
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_17:
+    slot: 17
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_18:
+    slot: 18
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_19:
+    slot: 19
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_20:
+    slot: 20
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_21:
+    slot: 21
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_22:
+    slot: 22
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_23:
+    slot: 23
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_24:
+    slot: 24
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_25:
+    slot: 25
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_26:
+    slot: 26
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_27:
+    slot: 27
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_28:
+    slot: 28
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_29:
+    slot: 29
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_30:
+    slot: 30
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_31:
+    slot: 31
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_32:
+    slot: 32
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_33:
+    slot: 33
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_34:
+    slot: 34
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_35:
+    slot: 35
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_36:
+    slot: 36
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_37:
+    slot: 37
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_38:
+    slot: 38
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_39:
+    slot: 39
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_40:
+    slot: 40
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_41:
+    slot: 41
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_42:
+    slot: 42
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_43:
+    slot: 43
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  welcome_44:
+    slot: 44
+    icon: GRAY_STAINED_GLASS_PANE
+    name: "%announcement_title%"
+    lore: ["%announcement_body%"]
+  profile:
+    slot: 45
+    icon: PLAYER_HEAD
+    name: "&f%player%"
+    lore:
+      - "&7オンライン: &e%online%&f人"
+      - "&7TPS: &a%tps%"
+      - "&7DP: &b%dp_level%"
+      - "&7所持金: &6%money%"
+      - "&7ポイント: &3%tokens%&fP"
+      - ""
+      - "&eクリックで自分のプロフィールへ"
+    actions:
+      - type: PLAYER_CMD
+        command: "dp"
+
+  channel:
+    slot: 46
+    icon: RED_CONCRETE_POWDER
+    name: "&cチャンネルメニュー"
+    lore: ["&7チャットチャンネルを切り替えます", "&7メンバー確認もここから"]
+    actions:
+      - type: OPEN_POPUP
+        target: "channel"
+  sell:
+    slot: 47
+    icon: ORANGE_CONCRETE_POWDER
+    name: "&6一括売却"
+    lore: ["&7アイテムを一括で売却します", "&7ショップでも買取可のアイテムのみ換金"]
+    actions:
+      - type: OPEN_POPUP
+        target: "sellmenu"
+  shop:
+    slot: 48
+    icon: YELLOW_CONCRETE_POWDER
+    name: "&eサーバーショップ"
+    lore: ["&7ブロック・鉱石・ツール等を", "&7購入・売却できます"]
+    actions:
+      - type: OPEN_POPUP
+        target: "shopindex"
+  sociallikes:
+    slot: 49
+    icon: LIME_CONCRETE_POWDER
+    name: "&aSocialLikes"
+    lore: ["&7建築を投稿・閲覧したり", "&7空き地へテレポートできます"]
+    actions:
+      - type: OPEN_POPUP
+        target: "sociallikes"
+  carbuilder:
+    slot: 50
+    icon: CYAN_CONCRETE_POWDER
+    name: "&bCarBuilder"
+    lore: ["&7ユーザー車両建造プラグイン", "&7スポーン、カスタム、車両設定など"]
+    actions:
+      - type: OPEN_POPUP
+        target: "carbuilder"
+  utility:
+    slot: 51
+    icon: BLUE_CONCRETE_POWDER
+    name: "&9ユーティリティ"
+    lore: ["&7ワープ・各種コマンドの", "&7ショートカット集です"]
+    actions:
+      - type: OPEN_POPUP
+        target: "utility"
+  macro:
+    slot: 52
+    icon: PURPLE_CONCRETE_POWDER
+    name: "&5マクロ"
+    lore: ["&7コマンドを登録・実行できる", "&7マクロ機能を管理します"]
+    actions:
+      - type: OPEN_POPUP
+        target: "macromenu"
+  links:
+    slot: 53
+    icon: PINK_CONCRETE_POWDER
+    name: "&dリンク集"
+    lore: ["&7Wiki・Discord・WebMAP など", "&7各種リンクを表示します"]
+    actions:
+      - type: OPEN_POPUP
+        target: "links"


### PR DESCRIPTION
## Summary
- add OP-only special menu and parameterized command menu support for OyasaiMenu
- add GUI maker actions/screens for creating special menus and parameter command actions
- optimize menu rendering by lazily evaluating placeholders, caching TPS, caching nav-bar player stats briefly, and avoiding per-item point-shop balance lookups

## Tests
- `nix fmt`
- `./gradlew spotlessKotlinCheck :plugins:OyasaiMenu:build`
- `nix flake check -L`

## Notes
- `CONTRIBUTING.md` was not present in this checkout, so I used the platform PR workflow fallback procedure.
- `nix flake check -L` completed successfully with existing deprecation warnings from multiple plugins.