### PR TITLE
fix(cities-skymine): align worldedit history handling

### DIFF
--- a/plugins/CitiesSkyMine/src/main/kotlin/icu/oyasai/citiesskymine/worldedit/CsmEditSession.kt
+++ b/plugins/CitiesSkyMine/src/main/kotlin/icu/oyasai/citiesskymine/worldedit/CsmEditSession.kt
@@ -31,8 +31,8 @@ object CsmEditSession {
         .use { editSession ->
           changed = edit(editSession)
           if (changed) {
-            Operations.complete(editSession.commit())
             undoRecorded = player?.let { FaweUndo.remember(it, editSession, logger) } ?: false
+            Operations.complete(editSession.commit())
           }
         }
     return Result(changed, undoRecorded)


### PR DESCRIPTION
## Summary
- Record FAWE/WorldEdit undo history before explicitly committing the edit session.
- Keep the change scoped to CitiesSkyMine code only; no Gradle, Nix, or shared dependency version changes are included.

## Validation
- `git diff --check`
- `ORG_GRADLE_PROJECT_csmLocalDeployEnabled=false nix develop --command gradle :plugins:CitiesSkyMine:build`
- `ORG_GRADLE_PROJECT_csmLocalDeployEnabled=false nix build .#checks.aarch64-darwin.build-oyasai-plugins -L`
- `nix build .#checks.aarch64-darwin.treefmt -L`

## Notes
- A full `nix flake check -L` was attempted, but the repository-wide check failed outside this change at `mkdirp-classic.drv` while building Node-related derivations.
- An attempted FAWE 2.15.2 dependency bump was removed because Nix's fixed Gradle Maven repository does not currently include that artifact. This PR now avoids shared dependency and Nix changes.
