### PR TITLE
fix(sociallikes3): replace broken anvil input

### DIFF
--- a/plugins/SocialLikes3/build.gradle.kts
+++ b/plugins/SocialLikes3/build.gradle.kts
@@ -7,7 +7,6 @@ dependencies {
   compileOnly(libs.fawe.bukkit)
   implementation(libs.kotlin.stdlib)
   implementation(libs.inventoryframework)
-  implementation(libs.anvilgui)
   implementation(libs.javacord)
   implementation(libs.ultimateadvancementapi)
 }

--- a/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/Events.kt
+++ b/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/Events.kt
@@ -1,6 +1,5 @@
 package com.github.srain3.sociallikes
 
-import com.fren_gor.ultimateAdvancementAPI.advancement.display.AdvancementFrameType
 import com.github.srain3.sociallikes.Tools.color
 import com.github.srain3.sociallikes.Tools.isLegacySLSign
 import com.github.srain3.sociallikes.Tools.isSLSign
@@ -251,12 +250,11 @@ object Events : Listener {
               this.clickEvent = ClickEvent(ClickEvent.Action.RUN_COMMAND, "/sociallikes3:sltp $id")
               this.hoverEvent = HoverEvent(HoverEvent.Action.SHOW_TEXT, Text("&nクリックでその建築へテレポート&rします".color()))
           })*/
-          Tools.advAPI.displayCustomToast(
+          Tools.displaySocialLikeToast(
               ownerPlayer,
               ItemStack(Material.OAK_SIGN),
               Tools.socialLikesLOGOShort +
                   "&a${data.title}&7ID:${id}&r\n${e.player.name}&7<&rイイね!".color(),
-              AdvancementFrameType.TASK,
           )
           ownerPlayer.playSound(ownerPlayer, Sound.ENTITY_PLAYER_LEVELUP, 1F, 1F)
           if (e.player.uniqueId != data.owner) {

--- a/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/SocialLikes.kt
+++ b/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/SocialLikes.kt
@@ -7,6 +7,7 @@ import com.github.srain3.sociallikes.datas.PlaceHolder
 import com.github.srain3.sociallikes.datas.PublicityHistory
 import com.github.srain3.sociallikes.discord.SLDiscord
 import com.github.srain3.sociallikes.gui.FollowBuild
+import com.github.srain3.sociallikes.gui.SocialLikesAnvilInput
 import java.io.File
 import org.bukkit.Bukkit
 import org.bukkit.plugin.java.JavaPlugin
@@ -23,6 +24,7 @@ class SocialLikes : JavaPlugin() {
 
     server.pluginManager.registerEvents(Events, this)
     server.pluginManager.registerEvents(FollowBuild, this)
+    server.pluginManager.registerEvents(SocialLikesAnvilInput, this)
 
     server.getPluginCommand("sltp")?.setExecutor(SLtp)
     server.getPluginCommand("slbuild")?.setExecutor(SLBuilds)

--- a/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/Tools.kt
+++ b/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/Tools.kt
@@ -1,6 +1,7 @@
 package com.github.srain3.sociallikes
 
 import com.fren_gor.ultimateAdvancementAPI.UltimateAdvancementAPI
+import com.fren_gor.ultimateAdvancementAPI.advancement.display.AdvancementFrameType
 import com.github.srain3.sociallikes.Events.idKey
 import com.github.srain3.sociallikes.datas.Data
 import com.github.srain3.sociallikes.datas.SLData
@@ -68,6 +69,8 @@ object Tools {
 
   /** SocialLikeロゴ？ */
   val socialLikesLOGOShort = "&8(&5S&7L&8)".color()
+
+  private var advancementToastDisabled = false
 
   /** ItemStackに表示名と説明を追加する(自動カラー化付き) */
   fun ItemStack.addText(title: String?, lore: MutableList<String>): ItemStack {
@@ -209,4 +212,26 @@ object Tools {
 
   /** AdvancementAPI */
   val advAPI by lazy { UltimateAdvancementAPI.getInstance(plugin) }
+
+  fun displaySocialLikeToast(player: Player, icon: ItemStack, text: String): Boolean {
+    if (advancementToastDisabled) return false
+    return try {
+      advAPI.displayCustomToast(player, icon, text, AdvancementFrameType.TASK)
+      true
+    } catch (throwable: LinkageError) {
+      disableAdvancementToast(throwable)
+    } catch (throwable: RuntimeException) {
+      disableAdvancementToast(throwable)
+    }
+  }
+
+  private fun disableAdvancementToast(throwable: Throwable): Boolean {
+    advancementToastDisabled = true
+    plugin.logger.warning(
+        "[SocialLikes3] Advancement toast notification has been disabled: " +
+            "${throwable.javaClass.name}: ${throwable.message}"
+    )
+    plugin.logger.warning("[SocialLikes3] Likes, rewards, and sign updates will continue.")
+    return false
+  }
 }

--- a/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/discord/SLDiscord.kt
+++ b/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/discord/SLDiscord.kt
@@ -1,6 +1,5 @@
 package com.github.srain3.sociallikes.discord
 
-import com.fren_gor.ultimateAdvancementAPI.advancement.display.AdvancementFrameType
 import com.github.srain3.sociallikes.CustomYaml
 import com.github.srain3.sociallikes.Events
 import com.github.srain3.sociallikes.Tools
@@ -91,12 +90,11 @@ object SLDiscord {
                           this.clickEvent = ClickEvent(ClickEvent.Action.RUN_COMMAND, "/sociallikes3:sltp $id")
                           this.hoverEvent = HoverEvent(HoverEvent.Action.SHOW_TEXT, Text("&nクリックでその建築へテレポート&rします".color()))
                       })*/
-                      Tools.advAPI.displayCustomToast(
+                      Tools.displaySocialLikeToast(
                           ownerPlayer,
                           ItemStack(Material.OAK_SIGN),
                           Tools.socialLikesLOGOShort +
                               "&a${data.title}&7ID:${id}&r\n${player.name}&7<&rイイね!".color(),
-                          AdvancementFrameType.TASK,
                       )
                       ownerPlayer.playSound(ownerPlayer, Sound.ENTITY_PLAYER_LEVELUP, 1F, 1F)
                       if (uuid != data.owner) {

--- a/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/gui/SLSignLikes.kt
+++ b/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/gui/SLSignLikes.kt
@@ -24,7 +24,6 @@ import net.md_5.bungee.api.chat.ClickEvent
 import net.md_5.bungee.api.chat.HoverEvent
 import net.md_5.bungee.api.chat.TextComponent
 import net.md_5.bungee.api.chat.hover.content.Text
-import net.wesjd.anvilgui.AnvilGUI
 import org.bukkit.Bukkit
 import org.bukkit.Material
 import org.bukkit.Sound
@@ -476,36 +475,23 @@ object SLSignLikes {
   }
 
   private fun commentEdit(player: Player, slData: SLData) {
-    AnvilGUI.Builder().apply {
-      itemLeft(
-          ItemStack(Material.WRITABLE_BOOK)
-              .allFlag()
-              .addText(
-                  slData.comment,
-                  mutableListOf(
-                      "&7出力先(右側)にあるこの本をクリックで確定します",
-                      "&7普通に閉じた場合はキャンセルです",
-                      "&7カンマ(,)で改行扱いします",
-                  ),
-              )
-      )
-      onClick { slot, e ->
-        if (slot != AnvilGUI.Slot.OUTPUT) {
-          return@onClick listOf()
-        }
-
-        if (e.text.isNotBlank()) {
-          slData.comment = e.text
-          Data.save(slData)
-          e.player.playSound(player, Sound.UI_BUTTON_CLICK, 1F, 1F)
-          return@onClick listOf(AnvilGUI.ResponseAction.close())
-        } else {
-          return@onClick listOf(AnvilGUI.ResponseAction.replaceInputText(""))
-        }
-      }
-      title(Tools.socialLikesLOGOShort + "&0コメント編集".color())
-      plugin(Tools.plugin)
-      open(player)
+    val item =
+        ItemStack(Material.WRITABLE_BOOK)
+            .allFlag()
+            .addText(
+                slData.comment,
+                mutableListOf(
+                    "&7出力先(右側)にあるこの本をクリックで確定します",
+                    "&7普通に閉じた場合はキャンセルです",
+                    "&7カンマ(,)で改行扱いします",
+                ),
+            )
+    SocialLikesAnvilInput.open(player, Tools.socialLikesLOGOShort + "&0コメント編集".color(), item) {
+        p,
+        text ->
+      slData.comment = text
+      Data.save(slData)
+      p.playSound(player, Sound.UI_BUTTON_CLICK, 1F, 1F)
     }
   }
 }

--- a/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/gui/SLSignSetting.kt
+++ b/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/gui/SLSignSetting.kt
@@ -20,7 +20,6 @@ import me.realized.tokenmanager.api.TokenManager
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.event.ClickEvent
 import net.kyori.adventure.text.format.TextColor
-import net.wesjd.anvilgui.AnvilGUI
 import org.bukkit.Bukkit
 import org.bukkit.Material
 import org.bukkit.NamespacedKey
@@ -492,7 +491,7 @@ object SLSignSetting {
                   .addText("&aタイトルを変更する", mutableListOf("&7看板のタイトルを変えれます"))
           ) {
             it.whoClicked.closeInventory()
-            titleChangeAnvilGUI(sign, slData, (it.whoClicked as Player))
+            titleChangeAnvilInput(sign, slData, (it.whoClicked as Player))
           },
           7,
           0,
@@ -574,41 +573,30 @@ object SLSignSetting {
     sign.update(true)
   }
 
-  private fun titleChangeAnvilGUI(sign: Sign, slData: SLData, player: Player) {
-    AnvilGUI.Builder().apply {
-      itemLeft(
-          ItemStack(Material.OAK_SIGN)
-              .allFlag()
-              .addText(
-                  slData.title,
-                  mutableListOf("&7出力先(右側)にあるこの看板をクリックで確定します", "&7普通に閉じた場合はキャンセルです"),
-              )
-      )
-      onClick { slot, e ->
-        if (slot != AnvilGUI.Slot.OUTPUT) {
-          return@onClick listOf()
-        }
-
-        if (e.text.isNotBlank()) {
-          sign.getSide(Side.FRONT).setLine(1, "&a${e.text}".color())
-          sign.update()
-          slData.title = e.text
-          Data.save(slData)
-          // GUIへ反映
-          AllBuild.updateSLSignData(slData)
-          UserBuild.updateSLSignData(slData)
-          e.player.sendMessage(Tools.socialLikesLOGO + "&r タイトルを変更しました!".color())
-          e.player.playSound(player, Sound.UI_BUTTON_CLICK, 1F, 1F)
-          // Discordへ反映
-          SLDiscord.changeSLDataToMsg(slData)
-          return@onClick listOf(AnvilGUI.ResponseAction.close())
-        } else {
-          return@onClick listOf(AnvilGUI.ResponseAction.replaceInputText(""))
-        }
-      }
-      title(Tools.socialLikesLOGOShort + "&0title change".color())
-      plugin(Tools.plugin)
-      open(player)
+  private fun titleChangeAnvilInput(sign: Sign, slData: SLData, player: Player) {
+    val item =
+        ItemStack(Material.OAK_SIGN)
+            .allFlag()
+            .addText(
+                slData.title,
+                mutableListOf("&7出力先(右側)にあるこの看板をクリックで確定します", "&7普通に閉じた場合はキャンセルです"),
+            )
+    SocialLikesAnvilInput.open(
+        player,
+        Tools.socialLikesLOGOShort + "&0title change".color(),
+        item,
+    ) { p, text ->
+      sign.getSide(Side.FRONT).setLine(1, "&a${text}".color())
+      sign.update()
+      slData.title = text
+      Data.save(slData)
+      // GUIへ反映
+      AllBuild.updateSLSignData(slData)
+      UserBuild.updateSLSignData(slData)
+      p.sendMessage(Tools.socialLikesLOGO + "&r タイトルを変更しました!".color())
+      p.playSound(player, Sound.UI_BUTTON_CLICK, 1F, 1F)
+      // Discordへ反映
+      SLDiscord.changeSLDataToMsg(slData)
     }
   }
 }

--- a/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/gui/SearchBuild.kt
+++ b/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/gui/SearchBuild.kt
@@ -12,7 +12,6 @@ import com.github.stefvanschie.inventoryframework.pane.PaginatedPane
 import com.github.stefvanschie.inventoryframework.pane.StaticPane
 import com.github.stefvanschie.inventoryframework.pane.util.Slot
 import java.time.format.DateTimeFormatter
-import net.wesjd.anvilgui.AnvilGUI
 import org.bukkit.*
 import org.bukkit.entity.Player
 import org.bukkit.event.inventory.InventoryClickEvent
@@ -125,50 +124,37 @@ object SearchBuild {
     return item
   }
 
-  /** オフラインプレイヤーを検索するためのAnvilGUIを開く */
+  /** 建築名検索用の金床入力を開く */
   fun offlinePlayerSearch(player: Player) {
-    AnvilGUI.Builder().apply {
-      itemLeft(
-          ItemStack(Material.OAK_SIGN)
-              .allFlag()
-              .addText(
-                  "ここに探したい建築名",
-                  mutableListOf("&7出力先(右側)にあるこの看板をクリックで確定します", "&7普通に閉じた場合はキャンセルです"),
-              )
-      )
-      onClick { slot, e ->
-        if (slot != AnvilGUI.Slot.OUTPUT) {
-          return@onClick listOf()
-        }
-
-        if (e.text.isNotBlank()) {
-          player.sendMessage(Tools.socialLikesLOGO + "&r 検索中です…".color())
-          Thread {
-                // 検索処理
-                val regex = Regex(e.text)
-                val slDataList = Data.getSLDataAll()
-                val hitSLDataList = slDataList.filter { regex.containsMatchIn(it.title) }
-                val gui = createGUI(hitSLDataList, e.text)
-                object : BukkitRunnable() {
-                      override fun run() {
-                        if (player.isOnline) {
-                          gui.show(player)
-                        }
-                      }
+    val item =
+        ItemStack(Material.OAK_SIGN)
+            .allFlag()
+            .addText(
+                "ここに探したい建築名",
+                mutableListOf("&7出力先(右側)にあるこの看板をクリックで確定します", "&7普通に閉じた場合はキャンセルです"),
+            )
+    SocialLikesAnvilInput.open(player, Tools.socialLikesLOGOShort + "&0建築名検索".color(), item) {
+        p,
+        text ->
+      p.sendMessage(Tools.socialLikesLOGO + "&r 検索中です…".color())
+      Thread {
+            // 検索処理
+            val regex = Regex(Regex.escape(text))
+            val slDataList = Data.getSLDataAll()
+            val hitSLDataList = slDataList.filter { regex.containsMatchIn(it.title) }
+            val gui = createGUI(hitSLDataList, text)
+            object : BukkitRunnable() {
+                  override fun run() {
+                    if (p.isOnline) {
+                      gui.show(p)
                     }
-                    .runTaskLater(Tools.plugin, 2)
-              }
-              .start()
+                  }
+                }
+                .runTaskLater(Tools.plugin, 2)
+          }
+          .start()
 
-          e.player.playSound(player, Sound.UI_BUTTON_CLICK, 1F, 1F)
-          return@onClick listOf(AnvilGUI.ResponseAction.close())
-        } else {
-          return@onClick listOf(AnvilGUI.ResponseAction.replaceInputText(""))
-        }
-      }
-      title(Tools.socialLikesLOGOShort + "&0建築名検索".color())
-      plugin(Tools.plugin)
-      open(player)
+      p.playSound(p, Sound.UI_BUTTON_CLICK, 1F, 1F)
     }
   }
 }

--- a/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/gui/SocialLikesAnvilInput.kt
+++ b/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/gui/SocialLikesAnvilInput.kt
@@ -1,0 +1,115 @@
+package com.github.srain3.sociallikes.gui
+
+import com.github.srain3.sociallikes.Tools
+import java.util.UUID
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.inventory.InventoryAction
+import org.bukkit.event.inventory.InventoryClickEvent
+import org.bukkit.event.inventory.InventoryCloseEvent
+import org.bukkit.event.inventory.PrepareAnvilEvent
+import org.bukkit.inventory.Inventory
+import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.MenuType
+import org.bukkit.inventory.view.AnvilView
+
+object SocialLikesAnvilInput : Listener {
+  private const val OUTPUT_SLOT = 2
+
+  private val legacySerializer = LegacyComponentSerializer.legacySection()
+  private val plainTextSerializer = PlainTextComponentSerializer.plainText()
+  private val sessions = mutableMapOf<UUID, Session>()
+
+  fun open(player: Player, title: String, itemLeft: ItemStack, onSubmit: (Player, String) -> Unit) {
+    val view =
+        MenuType.ANVIL.builder()
+            .title(legacySerializer.deserialize(title))
+            .checkReachable(false)
+            .build(player)
+    val session = Session(view.topInventory, itemLeft.clone(), onSubmit)
+    sessions[player.uniqueId] = session
+
+    configure(view)
+    view.topInventory.setItem(0, itemLeft.clone())
+    view.topInventory.setItem(OUTPUT_SLOT, createResultItem(session, view.renameText))
+    view.open()
+  }
+
+  @EventHandler
+  fun onPrepareAnvil(event: PrepareAnvilEvent) {
+    val player = event.view.player as? Player ?: return
+    val view = event.view
+    val session = sessions[player.uniqueId] ?: return
+    if (event.inventory != session.inventory) return
+
+    configure(view)
+    event.result = createResultItem(session, view.renameText)
+  }
+
+  @EventHandler
+  fun onInventoryClick(event: InventoryClickEvent) {
+    val player = event.whoClicked as? Player ?: return
+    val view = event.view as? AnvilView ?: return
+    val session = sessions[player.uniqueId] ?: return
+    if (view.topInventory != session.inventory) return
+
+    if (
+        event.rawSlot < view.topInventory.size ||
+            event.action == InventoryAction.MOVE_TO_OTHER_INVENTORY
+    ) {
+      event.isCancelled = true
+    }
+    if (event.rawSlot != OUTPUT_SLOT) return
+
+    val text = normalize(view.renameText)
+    if (text.isBlank()) {
+      view.topInventory.setItem(OUTPUT_SLOT, createResultItem(session, text))
+      return
+    }
+
+    sessions.remove(player.uniqueId)
+    player.closeInventory()
+    Tools.plugin.server.scheduler.runTask(Tools.plugin, Runnable { session.onSubmit(player, text) })
+  }
+
+  @EventHandler
+  fun onInventoryClose(event: InventoryCloseEvent) {
+    val player = event.player as? Player ?: return
+    val session = sessions[player.uniqueId] ?: return
+    if (event.view.topInventory == session.inventory) {
+      sessions.remove(player.uniqueId)
+    }
+  }
+
+  private fun configure(view: AnvilView) {
+    view.setRepairCost(0)
+    view.setRepairItemCountCost(0)
+    view.setMaximumRepairCost(Int.MAX_VALUE)
+    view.bypassEnchantmentLevelRestriction(true)
+  }
+
+  private fun createResultItem(session: Session, text: String?): ItemStack {
+    val item = session.resultItem.clone()
+    val normalizedText = normalize(text)
+    if (normalizedText.isNotBlank()) {
+      val meta = item.itemMeta ?: return item
+      meta.displayName(Component.text(normalizedText))
+      item.itemMeta = meta
+    }
+    return item
+  }
+
+  private fun normalize(text: String?): String {
+    return plainTextSerializer.serialize(legacySerializer.deserialize(text ?: "")).trim()
+  }
+
+  private data class Session(
+      val inventory: Inventory,
+      val resultItem: ItemStack,
+      val onSubmit: (Player, String) -> Unit,
+  )
+}

--- a/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/gui/UserBuild.kt
+++ b/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/gui/UserBuild.kt
@@ -13,7 +13,6 @@ import com.github.stefvanschie.inventoryframework.pane.util.Slot
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.*
-import net.wesjd.anvilgui.AnvilGUI
 import org.bukkit.*
 import org.bukkit.entity.HumanEntity
 import org.bukkit.entity.Player
@@ -330,40 +329,27 @@ object UserBuild {
     return headItemList
   }
 
-  /** オフラインプレイヤーを検索するためのAnvilGUIを開く */
+  /** オフラインプレイヤー検索用の金床入力を開く */
   @Suppress("DEPRECATION")
   private fun offlinePlayerSearch(player: Player) {
-    AnvilGUI.Builder().apply {
-      itemLeft(
-          ItemStack(Material.PLAYER_HEAD)
-              .allFlag()
-              .addText(
-                  "ここにプレイヤー名",
-                  mutableListOf("&7出力先(右側)にあるこのヘッドをクリックで確定します", "&7普通に閉じた場合はキャンセルです"),
-              )
-      )
-      onClick { slot, e ->
-        if (slot != AnvilGUI.Slot.OUTPUT) {
-          return@onClick listOf()
-        }
-
-        if (e.text.isNotBlank()) {
-          val sPlayer = Bukkit.getOfflinePlayer(e.text)
-          object : BukkitRunnable() {
-                override fun run() {
-                  createGUI(sPlayer, player).show(player)
-                }
-              }
-              .runTaskLater(Tools.plugin, 1)
-          e.player.playSound(player, Sound.UI_BUTTON_CLICK, 1F, 1F)
-          return@onClick listOf(AnvilGUI.ResponseAction.close())
-        } else {
-          return@onClick listOf(AnvilGUI.ResponseAction.replaceInputText(""))
-        }
-      }
-      title(Tools.socialLikesLOGOShort + "&0プレイヤー名検索".color())
-      plugin(Tools.plugin)
-      open(player)
+    val item =
+        ItemStack(Material.PLAYER_HEAD)
+            .allFlag()
+            .addText(
+                "ここにプレイヤー名",
+                mutableListOf("&7出力先(右側)にあるこのヘッドをクリックで確定します", "&7普通に閉じた場合はキャンセルです"),
+            )
+    SocialLikesAnvilInput.open(player, Tools.socialLikesLOGOShort + "&0プレイヤー名検索".color(), item) {
+        p,
+        text ->
+      val sPlayer = Bukkit.getOfflinePlayer(text)
+      object : BukkitRunnable() {
+            override fun run() {
+              createGUI(sPlayer, p).show(p)
+            }
+          }
+          .runTaskLater(Tools.plugin, 1)
+      p.playSound(p, Sound.UI_BUTTON_CLICK, 1F, 1F)
     }
   }
 }


### PR DESCRIPTION
## Summary
- replace the broken shaded AnvilGUI dependency with a Paper/Purpur MenuType ANVIL input handler
- route SocialLikes search, title edit, and comment edit flows through the new input handler
- guard UltimateAdvancementAPI toast failures so likes, TokenManager rewards, and sign updates continue on Minecraft 1.21.11

## Production context
- production `oyasai-minecraft-main` is running Purpur 1.21.11
- current production logs show repeated SocialLikes3 failures from both `net/minecraft/world/inventory/Container` and `net/minecraft/ResourceKeyInvalidException`
- current production jar still contains `net/wesjd/anvilgui/AnvilGUI.class` and does not contain `SocialLikesAnvilInput.class`

## Tests
- `nix fmt`
- `git diff --check`
- `./gradlew :plugins:SocialLikes3:build --console=plain`
- `ORG_GRADLE_PROJECT_csmLocalDeployEnabled=false nix build .#checks.aarch64-darwin.build-oyasai-plugins -L`
- `nix flake check -L` failed outside this plugin change while building `/nix/store/hpqzjp7538gjsmny0hqlnrzplyciyi6a-foreground-child.drv`; the log only reached `plan9UnpackPhase` / `unpackPhase` before the derivation failed, and unrelated checks were cancelled.

## Deployment note
- Deploy with a full `oyasai-minecraft-main` restart, not PlugMan reload for SocialLikes3.
- After deployment, smoke test with a different player liking a sign and verify the owner receives `+2 tokens` and no new AnvilGUI / UltimateAdvancementAPI stack traces appear.
