### PR TITLE
fix(sociallikes3): build with paperweight userdev

### DIFF
--- a/plugins/SocialLikes3/build.gradle.kts
+++ b/plugins/SocialLikes3/build.gradle.kts
@@ -1,5 +1,7 @@
+plugins { alias(libs.plugins.paperweight.userdev) }
+
 dependencies {
-  compileOnly(libs.purpur.api)
+  paperweightDevelopmentBundle(libs.paper.dev.bundle)
   compileOnly(libs.placeholderapi)
   compileOnly(libs.discordsrv)
   compileOnly(libs.luckperms.api)


### PR DESCRIPTION
## Summary
- Build SocialLikes3 with Paperweight userdev, matching the existing Paper/Purpur-oriented build style used by OyasaiUtilities and OyasaiVehicles.
- Replace the direct Purpur API compileOnly dependency with the Paper dev bundle to avoid Bukkit capability conflicts.
- Ensure the distributed SocialLikes3 jar is marked with `paperweight-mappings-namespace: mojang`, allowing Paper/Purpur plugin remapping to handle shaded UAAPI NMS references.

## Validation
- `nix fmt`
- `git diff --check`
- `./gradlew :plugins:SocialLikes3:build --console=plain`
- `ORG_GRADLE_PROJECT_csmLocalDeployEnabled=false nix build .#checks.aarch64-darwin.build-oyasai-plugins -L`
- `nix flake check -L`
- Verified `result/SocialLikes3.jar` manifest contains `paperweight-mappings-namespace: mojang`.

## Note
- An earlier `nix flake check -L` attempt stopped while building the CDKTF Node dependency `universalify`, but that derivation rebuilt successfully on its own and the full flake check passed on rerun. This was not reproducible as a SocialLikes3 build failure.