### PR TITLE
fix(sociallikes3): recover timestamps and toast notifications

### DIFF
--- a/plugins/SocialLikes3/build.gradle.kts
+++ b/plugins/SocialLikes3/build.gradle.kts
@@ -10,7 +10,6 @@ dependencies {
   implementation(libs.kotlin.stdlib)
   implementation(libs.inventoryframework)
   implementation(libs.javacord)
-  implementation(libs.ultimateadvancementapi)
   implementation(libs.exposed.core)
   implementation(libs.exposed.jdbc)
   implementation(libs.sqlite.jdbc)

--- a/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/Events.kt
+++ b/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/Events.kt
@@ -254,14 +254,11 @@ object Events : Listener {
               ownerPlayer,
               ItemStack(Material.OAK_SIGN),
               Tools.socialLikesLOGOShort +
-                  "&a${data.title}&7ID:${id}&r\n${e.player.name}&7<&rイイね!".color(),
+                  "&a${data.title} &7ID:${id}&r\n${e.player.name}&7 > &rイイね!".color(),
           )
           ownerPlayer.playSound(ownerPlayer, Sound.ENTITY_PLAYER_LEVELUP, 1F, 1F)
           if (e.player.uniqueId != data.owner) {
-            Bukkit.dispatchCommand(
-                Bukkit.getConsoleSender(),
-                "tokenmanager:tm add ${ownerPlayer.name} 2",
-            )
+            Tools.addTokens(ownerPlayer, 2)
           }
         } else {
           offlineLikesPoint[data.owner] = (offlineLikesPoint[data.owner] ?: 0) + 2
@@ -375,10 +372,7 @@ object Events : Listener {
   @EventHandler
   fun joinEvent(e: PlayerJoinEvent) {
     val pointInt = offlineLikesPoint[e.player.uniqueId] ?: return
-    Bukkit.dispatchCommand(
-        Bukkit.getConsoleSender(),
-        "tokenmanager:tm add ${e.player.name} $pointInt",
-    )
+    Tools.addTokens(e.player, pointInt.toLong())
     offlineLikesPoint.remove(e.player.uniqueId)
   }
 

--- a/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/SocialLikes.kt
+++ b/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/SocialLikes.kt
@@ -1,6 +1,5 @@
 package com.github.srain3.sociallikes
 
-import com.fren_gor.ultimateAdvancementAPI.AdvancementMain
 import com.github.srain3.sociallikes.command.*
 import com.github.srain3.sociallikes.datas.Data
 import com.github.srain3.sociallikes.datas.PlaceHolder
@@ -9,19 +8,21 @@ import com.github.srain3.sociallikes.datas.SLDatabase
 import com.github.srain3.sociallikes.discord.SLDiscord
 import com.github.srain3.sociallikes.gui.FollowBuild
 import com.github.srain3.sociallikes.gui.SocialLikesAnvilInput
-import java.io.File
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.StandardCopyOption
+import java.nio.file.attribute.BasicFileAttributes
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import org.bukkit.Bukkit
 import org.bukkit.plugin.java.JavaPlugin
 
 class SocialLikes : JavaPlugin() {
-  private val advMain by lazy { AdvancementMain(this) }
-
-  override fun onLoad() {
-    advMain.load()
-  }
-
   override fun onEnable() {
-    advMain.enableSQLite(File(this.dataFolder, "Advancement.db"))
+    backupPluginDataOnStartup()
+
     SLDatabase.init(this)
 
     server.pluginManager.registerEvents(Events, this)
@@ -56,7 +57,6 @@ class SocialLikes : JavaPlugin() {
   }
 
   override fun onDisable() {
-    advMain.disable()
     SLDiscord.disable()
 
     if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
@@ -65,5 +65,46 @@ class SocialLikes : JavaPlugin() {
     SLtp.userLastSLTPTimeSave()
     Events.offlineLikePointSave()
     SLDatabase.close()
+  }
+
+  private fun backupPluginDataOnStartup() {
+    if (!dataFolder.exists()) {
+      return
+    }
+
+    val pluginsDir =
+        dataFolder.parentFile?.toPath()
+            ?: throw IllegalStateException("[SocialLikes3] Could not resolve plugins directory")
+    val timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"))
+    val backupDir = pluginsDir.resolve("SocialLikes3-backups").resolve("startup-$timestamp")
+
+    try {
+      copyDirectory(dataFolder.toPath(), backupDir)
+      logger.info("[SocialLikes3] Startup backup created: $backupDir")
+    } catch (e: Exception) {
+      logger.severe("[SocialLikes3] Startup backup failed: ${e.message}")
+      throw IllegalStateException("SocialLikes3 startup backup failed", e)
+    }
+  }
+
+  private fun copyDirectory(source: Path, target: Path) {
+    Files.walkFileTree(
+        source,
+        object : SimpleFileVisitor<Path>() {
+          override fun preVisitDirectory(dir: Path, attrs: BasicFileAttributes) =
+              FileVisitResult.CONTINUE.also {
+                Files.createDirectories(target.resolve(source.relativize(dir)))
+              }
+
+          override fun visitFile(file: Path, attrs: BasicFileAttributes) =
+              FileVisitResult.CONTINUE.also {
+                Files.copy(
+                    file,
+                    target.resolve(source.relativize(file)),
+                    StandardCopyOption.COPY_ATTRIBUTES,
+                )
+              }
+        },
+    )
   }
 }

--- a/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/Tools.kt
+++ b/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/Tools.kt
@@ -1,18 +1,20 @@
 package com.github.srain3.sociallikes
 
-import com.fren_gor.ultimateAdvancementAPI.UltimateAdvancementAPI
-import com.fren_gor.ultimateAdvancementAPI.advancement.display.AdvancementFrameType
 import com.github.srain3.sociallikes.Events.idKey
 import com.github.srain3.sociallikes.datas.Data
 import com.github.srain3.sociallikes.datas.SLData
 import com.github.srain3.sociallikes.discord.SLDiscord
 import java.io.File
+import java.util.concurrent.atomic.AtomicLong
 import kotlin.collections.set
 import me.realized.tokenmanager.api.TokenManager
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer
 import net.luckperms.api.LuckPermsProvider
 import org.bukkit.Bukkit
 import org.bukkit.ChatColor
 import org.bukkit.Material
+import org.bukkit.NamespacedKey
 import org.bukkit.block.BlockState
 import org.bukkit.block.Sign
 import org.bukkit.block.sign.Side
@@ -34,12 +36,22 @@ object Tools {
 
   /** TokenManagerを返す、無ければnull */
   fun getTokenManager(): TokenManager? {
-    val tmPlugin = Bukkit.getServer().pluginManager.getPlugin("TokenManager")
-    return if (tmPlugin != null) {
-      tmPlugin as TokenManager
-    } else {
-      null
+    Bukkit.getServer().servicesManager.getRegistration(TokenManager::class.java)?.provider?.let {
+      return it
     }
+
+    return Bukkit.getServer().pluginManager.getPlugin("TokenManager") as? TokenManager
+  }
+
+  fun addTokens(player: Player, amount: Long): Boolean {
+    val tokenManager = getTokenManager()
+    if (tokenManager == null) {
+      plugin.logger.warning(
+          "TokenManager is not available. Failed to add $amount tokens to ${player.name}."
+      )
+      return false
+    }
+    return tokenManager.addTokens(player, amount)
   }
 
   fun canUseCreative(player: Player): Boolean {
@@ -70,6 +82,11 @@ object Tools {
   /** SocialLikeロゴ？ */
   val socialLikesLOGOShort = "&8(&5S&7L&8)".color()
 
+  private const val TOAST_CRITERION = "trigger"
+  private val legacyAmpersandColorRegex = Regex("(?i)&[0-9A-FK-OR]")
+  private val legacySectionSerializer = LegacyComponentSerializer.legacySection()
+  private val gsonComponentSerializer = GsonComponentSerializer.gson()
+  private val advancementToastSequence = AtomicLong()
   private var advancementToastDisabled = false
 
   /** ItemStackに表示名と説明を追加する(自動カラー化付き) */
@@ -210,28 +227,118 @@ object Tools {
     block.update()
   }
 
-  /** AdvancementAPI */
-  val advAPI by lazy { UltimateAdvancementAPI.getInstance(plugin) }
-
   fun displaySocialLikeToast(player: Player, icon: ItemStack, text: String): Boolean {
-    if (advancementToastDisabled) return false
+    val fallbackText = text.withoutLegacyColorCodes()
+    if (advancementToastDisabled) {
+      sendSocialLikeActionBar(player, fallbackText)
+      return false
+    }
     return try {
-      advAPI.displayCustomToast(player, icon, text, AdvancementFrameType.TASK)
+      loadAndAwardSocialLikeToast(player, icon, text)
       true
     } catch (throwable: LinkageError) {
-      disableAdvancementToast(throwable)
+      handleAdvancementToastFailure(player, fallbackText, throwable)
     } catch (throwable: RuntimeException) {
-      disableAdvancementToast(throwable)
+      handleAdvancementToastFailure(player, fallbackText, throwable)
     }
   }
 
-  private fun disableAdvancementToast(throwable: Throwable): Boolean {
+  private fun loadAndAwardSocialLikeToast(player: Player, icon: ItemStack, text: String) {
+    val key =
+        NamespacedKey(
+            plugin,
+            "social_like_toast_" +
+                player.uniqueId.toString().replace("-", "") +
+                "_" +
+                System.currentTimeMillis() +
+                "_" +
+                advancementToastSequence.incrementAndGet(),
+        )
+    val advancement =
+        Bukkit.getUnsafe().loadAdvancement(key, createSocialLikeToastJson(icon, text))
+            ?: throw IllegalStateException("Bukkit returned null advancement for $key")
+
+    player.getAdvancementProgress(advancement).awardCriteria(TOAST_CRITERION)
+    Bukkit.getScheduler()
+        .runTaskLater(
+            plugin,
+            Runnable {
+              try {
+                Bukkit.getPlayer(player.uniqueId)
+                    ?.getAdvancementProgress(advancement)
+                    ?.takeIf { TOAST_CRITERION in it.awardedCriteria }
+                    ?.revokeCriteria(TOAST_CRITERION)
+              } finally {
+                Bukkit.getUnsafe().removeAdvancement(key)
+              }
+            },
+            20L,
+        )
+  }
+
+  private fun createSocialLikeToastJson(icon: ItemStack, text: String): String {
+    val title = text.ifBlank { "SocialLikes" }
+    val iconType = icon.type.takeIf { it.isItem } ?: Material.OAK_SIGN
+
+    return """
+      {
+        "criteria": {
+          "$TOAST_CRITERION": {
+            "trigger": "minecraft:impossible"
+          }
+        },
+        "display": {
+          "announce_to_chat": false,
+          "background": "minecraft:gui/advancements/backgrounds/adventure",
+          "description": ${legacyJsonText("\n§7A notification.")},
+          "frame": "task",
+          "hidden": true,
+          "icon": {
+            "count": 1,
+            "id": "${iconType.key.asString()}"
+          },
+          "show_toast": true,
+          "title": ${legacyJsonText(title)}
+        },
+        "requirements": [
+          [
+            "$TOAST_CRITERION"
+          ]
+        ],
+        "sends_telemetry_event": false
+      }
+      """
+        .trimIndent()
+  }
+
+  private fun legacyJsonText(text: String): String {
+    return gsonComponentSerializer.serialize(legacySectionSerializer.deserialize(text))
+  }
+
+  private fun String.withoutLegacyColorCodes(): String {
+    return (ChatColor.stripColor(this) ?: this).replace(legacyAmpersandColorRegex, "")
+  }
+
+  private fun handleAdvancementToastFailure(
+      player: Player,
+      text: String,
+      throwable: Throwable,
+  ): Boolean {
+    disableAdvancementToast(throwable)
+    sendSocialLikeActionBar(player, text)
+    return false
+  }
+
+  private fun sendSocialLikeActionBar(player: Player, text: String) {
+    player.sendActionBar(text.lines().filter { it.isNotBlank() }.joinToString(" "))
+  }
+
+  private fun disableAdvancementToast(throwable: Throwable) {
     advancementToastDisabled = true
     plugin.logger.warning(
         "[SocialLikes3] Advancement toast notification has been disabled: " +
             "${throwable.javaClass.name}: ${throwable.message}"
     )
     plugin.logger.warning("[SocialLikes3] Likes, rewards, and sign updates will continue.")
-    return false
   }
 }

--- a/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/datas/Data.kt
+++ b/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/datas/Data.kt
@@ -18,6 +18,7 @@ import org.bukkit.Location
 import org.bukkit.Material
 import org.bukkit.block.Biome
 import org.bukkit.block.BlockFace
+import org.bukkit.configuration.ConfigurationSection
 import org.bukkit.entity.Player
 import org.bukkit.scheduler.BukkitRunnable
 
@@ -248,17 +249,7 @@ object Data {
                   likesStr.forEach { uuidStr -> likes.add(UUID.fromString(uuidStr)) }
 
                   // likesWithTimestampのロード
-                  val rawLikesWithTimestamp = yml.get("likesWithTimestamp")
-                  val likesWithTimestamp: MutableMap<UUID, Long> = mutableMapOf()
-                  if (rawLikesWithTimestamp is Map<*, *>) {
-                    rawLikesWithTimestamp.forEach { (k, v) ->
-                      try {
-                        val uuid = UUID.fromString(k as String)
-                        val ts = (v as? Number)?.toLong() ?: v.toString().toLongOrNull()
-                        if (ts != null) likesWithTimestamp[uuid] = ts
-                      } catch (_: Exception) {}
-                    }
-                  }
+                  val likesWithTimestamp = loadLikesWithTimestamp(yml)
 
                   // Cacheへ入れる
                   val slData =
@@ -324,6 +315,43 @@ object Data {
             "SL3-loadFileToDataCache",
         )
         .start()
+  }
+
+  private fun loadLikesWithTimestamp(yml: CustomYamlFile): MutableMap<UUID, Long> {
+    val likesWithTimestamp: MutableMap<UUID, Long> = mutableMapOf()
+    val section = yml.getConfigurationSection("likesWithTimestamp")
+
+    if (section != null) {
+      section.getKeys(false).forEach { uuidStr ->
+        putLikeTimestamp(likesWithTimestamp, uuidStr, section.get(uuidStr))
+      }
+      return likesWithTimestamp
+    }
+
+    val rawLikesWithTimestamp = yml.get("likesWithTimestamp")
+    if (rawLikesWithTimestamp is Map<*, *>) {
+      rawLikesWithTimestamp.forEach { (uuid, timestamp) ->
+        putLikeTimestamp(likesWithTimestamp, uuid as? String, timestamp)
+      }
+    } else if (rawLikesWithTimestamp is ConfigurationSection) {
+      rawLikesWithTimestamp.getKeys(false).forEach { uuidStr ->
+        putLikeTimestamp(likesWithTimestamp, uuidStr, rawLikesWithTimestamp.get(uuidStr))
+      }
+    }
+
+    return likesWithTimestamp
+  }
+
+  private fun putLikeTimestamp(
+      likesWithTimestamp: MutableMap<UUID, Long>,
+      uuidStr: String?,
+      timestamp: Any?,
+  ) {
+    try {
+      val uuid = UUID.fromString(uuidStr ?: return)
+      val ts = (timestamp as? Number)?.toLong() ?: timestamp?.toString()?.toLongOrNull() ?: return
+      likesWithTimestamp[uuid] = ts
+    } catch (_: Exception) {}
   }
 
   /** WorldNameとchunk別のslDataMap */

--- a/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/discord/SLDiscord.kt
+++ b/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/discord/SLDiscord.kt
@@ -1,24 +1,12 @@
 package com.github.srain3.sociallikes.discord
 
 import com.github.srain3.sociallikes.CustomYaml
-import com.github.srain3.sociallikes.Events
 import com.github.srain3.sociallikes.Tools
-import com.github.srain3.sociallikes.Tools.color
-import com.github.srain3.sociallikes.datas.Data
 import com.github.srain3.sociallikes.datas.SLData
-import com.github.srain3.sociallikes.gui.AllBuild
-import com.github.srain3.sociallikes.gui.UserBuild
-import github.scarsz.discordsrv.DiscordSRV
 import java.awt.Color
 import java.time.format.DateTimeFormatter
 import org.bukkit.Bukkit
 import org.bukkit.Location
-import org.bukkit.Material
-import org.bukkit.Sound
-import org.bukkit.block.Sign
-import org.bukkit.block.sign.Side
-import org.bukkit.inventory.ItemStack
-import org.bukkit.scheduler.BukkitRunnable
 import org.javacord.api.DiscordApi
 import org.javacord.api.DiscordApiBuilder
 import org.javacord.api.entity.message.embed.EmbedBuilder
@@ -52,97 +40,7 @@ object SLDiscord {
     DiscordApiBuilder()
         .setToken(token)
         .login()
-        .thenAccept {
-          discordApi = it
-          it.addReactionAddListener { event ->
-            if (event.channel.id != textChID) return@addReactionAddListener
-            if (!event.emoji.equalsEmoji("👍")) {
-              return@addReactionAddListener
-            }
-            val uuid =
-                DiscordSRV.getPlugin().accountLinkManager.linkedAccounts[event.userIdAsString]
-                    ?: return@addReactionAddListener
-            val player = Bukkit.getOfflinePlayer(uuid)
-
-            // いいねを行う処理
-            if (!Data.loading) return@addReactionAddListener
-            val messageID = event.messageId
-            val embed = event.channel.getMessageById(messageID)
-            val id = embed.get().embeds.first().description.get().replace("ID:", "").toInt()
-            val data = Data.getSLData(id) ?: return@addReactionAddListener
-
-            // 良いねを行っているか判断
-            if (!data.likes.none { likeUUID -> likeUUID == uuid }) return@addReactionAddListener
-            // いいねを行う
-            // データに記録・保存する
-            data.likes.add(uuid)
-            Data.save(data)
-            Data.changeUserLikesInt(data.owner, 1)
-            AllBuild.updateSLSignData(data)
-            UserBuild.updateSLSignData(data)
-
-            object : BukkitRunnable() {
-                  override fun run() {
-                    // 制作者がオンラインの場合通知
-                    val ownerPlayer = Bukkit.getPlayer(data.owner)
-                    if (ownerPlayer?.isOnline == true) {
-                      /*ownerPlayer.spigot().sendMessage(TextComponent(Tools.socialLikesLOGO + "&r「&a${data.title}&7(ID:${id})&r」が ${e.player.name}さんからイイねされました！".color()).apply {
-                          this.clickEvent = ClickEvent(ClickEvent.Action.RUN_COMMAND, "/sociallikes3:sltp $id")
-                          this.hoverEvent = HoverEvent(HoverEvent.Action.SHOW_TEXT, Text("&nクリックでその建築へテレポート&rします".color()))
-                      })*/
-                      Tools.displaySocialLikeToast(
-                          ownerPlayer,
-                          ItemStack(Material.OAK_SIGN),
-                          Tools.socialLikesLOGOShort +
-                              "&a${data.title}&7ID:${id}&r\n${player.name}&7<&rイイね!".color(),
-                      )
-                      ownerPlayer.playSound(ownerPlayer, Sound.ENTITY_PLAYER_LEVELUP, 1F, 1F)
-                      if (uuid != data.owner) {
-                        Bukkit.dispatchCommand(
-                            Bukkit.getConsoleSender(),
-                            "tokenmanager:tm add ${ownerPlayer.name} 2",
-                        )
-                      }
-                    } else {
-                      Events.offlineLikesPoint[data.owner] =
-                          (Events.offlineLikesPoint[data.owner] ?: 0) + 2
-                    }
-                    val block = data.loc.block.state
-                    if (block !is Sign) return
-                    // 看板ブロックへlike数を反映させる
-                    if (
-                        Events.checkMarkRegex.containsMatchIn(block.getSide(Side.FRONT).getLine(3))
-                    ) {
-                      block
-                          .getSide(Side.FRONT)
-                          .setLine(3, "&7Likes&8: &6${data.likes.count()} &e✓".color())
-                      if (player.isOp) {
-                        if (!data.check) {
-                          data.check = true
-                          Data.save(data)
-                        }
-                      }
-                    } else {
-                      if (player.isOp) {
-                        block
-                            .getSide(Side.FRONT)
-                            .setLine(3, "&7Likes&8: &6${data.likes.count()} &e✓".color())
-                        if (!data.check) {
-                          data.check = true
-                          Data.save(data)
-                        }
-                      } else {
-                        block
-                            .getSide(Side.FRONT)
-                            .setLine(3, "&7Likes&8: &6${data.likes.count()}".color())
-                      }
-                    }
-                    block.update()
-                  }
-                }
-                .runTask(Tools.plugin)
-          }
-        }
+        .thenAccept { discordApi = it }
         .exceptionally { _: Throwable? ->
           // Log a warning when the login to Discord failed (wrong token?)
           Tools.plugin.logger.warning("Failed to connect to Discord! Disabling plugin!")


### PR DESCRIPTION
## Summary
- Restore loading of existing likesWithTimestamp entries from Bukkit YAML configuration sections.
- Replace the broken UltimateAdvancementAPI toast path with a Paper/Bukkit advancement toast and keep a readable fallback action bar.
- Add startup data backups and remove Discord reaction-driven SocialLikes mutations.
- Route SocialLikes token rewards through the TokenManager service/API instead of console commands.

## Tests
- `/nix/var/nix/profiles/default/bin/nix fmt`
- `./gradlew :plugins:SocialLikes3:build --no-daemon`
- `./gradlew spotlessCheck --no-daemon`
- `git diff --check HEAD`

Not run: `nix flake check -L` (focused SocialLikes3 plugin change; targeted build and formatter were run).