### PR TITLE
fix(sociallikes3): send like toast via packets

### DIFF
--- a/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/SocialLikeToastSender.kt
+++ b/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/SocialLikeToastSender.kt
@@ -1,0 +1,139 @@
+package com.github.srain3.sociallikes
+
+import java.util.Optional
+import java.util.concurrent.atomic.AtomicLong
+import net.minecraft.advancements.Advancement
+import net.minecraft.advancements.AdvancementHolder
+import net.minecraft.advancements.AdvancementProgress
+import net.minecraft.advancements.AdvancementRequirements
+import net.minecraft.advancements.AdvancementRewards
+import net.minecraft.advancements.AdvancementType
+import net.minecraft.advancements.Criterion
+import net.minecraft.advancements.DisplayInfo
+import net.minecraft.core.ClientAsset
+import net.minecraft.network.chat.Component
+import net.minecraft.network.protocol.game.ClientboundUpdateAdvancementsPacket
+import net.minecraft.resources.Identifier
+import org.bukkit.Material
+import org.bukkit.craftbukkit.entity.CraftPlayer
+import org.bukkit.craftbukkit.inventory.CraftItemStack
+import org.bukkit.entity.Player
+import org.bukkit.inventory.ItemStack as BukkitItemStack
+
+object SocialLikeToastSender {
+  private const val NAMESPACE = "sociallikes3"
+  private const val ROOT_CRITERION = "root"
+  private const val TOAST_CRITERION = "trigger"
+  private val sequence = AtomicLong()
+  private val noBackground: Optional<ClientAsset.ResourceTexture> = Optional.empty()
+  private val noParent: Optional<Identifier> = Optional.empty()
+  private val criteria: Map<String, Criterion<*>> = emptyMap()
+
+  fun display(player: Player, icon: BukkitItemStack, title: String) {
+    val serial = nextSerial(player)
+    val rootId = Identifier.fromNamespaceAndPath(NAMESPACE, "toast_root_$serial")
+    val toastId = Identifier.fromNamespaceAndPath(NAMESPACE, "toast_$serial")
+
+    val rootRequirements = AdvancementRequirements.allOf(listOf(ROOT_CRITERION))
+    val toastRequirements = AdvancementRequirements.allOf(listOf(TOAST_CRITERION))
+    val root =
+        AdvancementHolder(
+            rootId,
+            advancement(
+                noParent,
+                DisplayInfo(
+                    CraftItemStack.asNMSCopy(BukkitItemStack(Material.GRASS_BLOCK)),
+                    Component.literal("SocialLikes"),
+                    Component.literal("SocialLikes notification root."),
+                    noBackground,
+                    AdvancementType.TASK,
+                    false,
+                    false,
+                    true,
+                ),
+                rootRequirements,
+            ),
+        )
+    val toastDisplay =
+        DisplayInfo(
+            nmsIcon(icon),
+            legacyComponent(title.ifBlank { "SocialLikes" }),
+            legacyComponent("\n§7A notification."),
+            noBackground,
+            AdvancementType.TASK,
+            true,
+            false,
+            true,
+        )
+    toastDisplay.setLocation(1F, 0F)
+    val toast =
+        AdvancementHolder(
+            toastId,
+            advancement(Optional.of(rootId), toastDisplay, toastRequirements),
+        )
+
+    val addPacket =
+        ClientboundUpdateAdvancementsPacket(
+            false,
+            listOf(root, toast),
+            emptySet(),
+            mapOf(
+                rootId to completedProgress(rootRequirements, ROOT_CRITERION),
+                toastId to completedProgress(toastRequirements, TOAST_CRITERION),
+            ),
+            true,
+        )
+    val removePacket =
+        ClientboundUpdateAdvancementsPacket(
+            false,
+            emptyList(),
+            setOf(rootId, toastId),
+            emptyMap(),
+            true,
+        )
+
+    val connection = (player as CraftPlayer).handle.connection
+    connection.send(addPacket)
+    connection.send(removePacket)
+  }
+
+  private fun nextSerial(player: Player): String {
+    return player.uniqueId.toString().replace("-", "") + "_" + sequence.incrementAndGet()
+  }
+
+  private fun advancement(
+      parent: Optional<Identifier>,
+      display: DisplayInfo,
+      requirements: AdvancementRequirements,
+  ): Advancement {
+    return Advancement(
+        parent,
+        Optional.of(display),
+        AdvancementRewards.EMPTY,
+        criteria,
+        requirements,
+        false,
+    )
+  }
+
+  private fun completedProgress(
+      requirements: AdvancementRequirements,
+      criterion: String,
+  ): AdvancementProgress {
+    return AdvancementProgress().also {
+      it.update(requirements)
+      it.grantProgress(criterion)
+    }
+  }
+
+  private fun nmsIcon(icon: BukkitItemStack): net.minecraft.world.item.ItemStack {
+    val source = if (icon.type.isItem) icon else BukkitItemStack(Material.OAK_SIGN)
+    val nmsStack = CraftItemStack.asNMSCopy(source)
+    return if (nmsStack.isEmpty) CraftItemStack.asNMSCopy(BukkitItemStack(Material.OAK_SIGN))
+    else nmsStack
+  }
+
+  private fun legacyComponent(text: String): Component {
+    return org.bukkit.craftbukkit.util.CraftChatMessage.fromStringOrEmpty(text)
+  }
+}

--- a/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/Tools.kt
+++ b/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/Tools.kt
@@ -5,16 +5,12 @@ import com.github.srain3.sociallikes.datas.Data
 import com.github.srain3.sociallikes.datas.SLData
 import com.github.srain3.sociallikes.discord.SLDiscord
 import java.io.File
-import java.util.concurrent.atomic.AtomicLong
 import kotlin.collections.set
 import me.realized.tokenmanager.api.TokenManager
-import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer
-import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer
 import net.luckperms.api.LuckPermsProvider
 import org.bukkit.Bukkit
 import org.bukkit.ChatColor
 import org.bukkit.Material
-import org.bukkit.NamespacedKey
 import org.bukkit.block.BlockState
 import org.bukkit.block.Sign
 import org.bukkit.block.sign.Side
@@ -82,11 +78,7 @@ object Tools {
   /** SocialLikeロゴ？ */
   val socialLikesLOGOShort = "&8(&5S&7L&8)".color()
 
-  private const val TOAST_CRITERION = "trigger"
   private val legacyAmpersandColorRegex = Regex("(?i)&[0-9A-FK-OR]")
-  private val legacySectionSerializer = LegacyComponentSerializer.legacySection()
-  private val gsonComponentSerializer = GsonComponentSerializer.gson()
-  private val advancementToastSequence = AtomicLong()
   private var advancementToastDisabled = false
 
   /** ItemStackに表示名と説明を追加する(自動カラー化付き) */
@@ -234,85 +226,13 @@ object Tools {
       return false
     }
     return try {
-      loadAndAwardSocialLikeToast(player, icon, text)
+      SocialLikeToastSender.display(player, icon, text)
       true
     } catch (throwable: LinkageError) {
       handleAdvancementToastFailure(player, fallbackText, throwable)
     } catch (throwable: RuntimeException) {
       handleAdvancementToastFailure(player, fallbackText, throwable)
     }
-  }
-
-  private fun loadAndAwardSocialLikeToast(player: Player, icon: ItemStack, text: String) {
-    val key =
-        NamespacedKey(
-            plugin,
-            "social_like_toast_" +
-                player.uniqueId.toString().replace("-", "") +
-                "_" +
-                System.currentTimeMillis() +
-                "_" +
-                advancementToastSequence.incrementAndGet(),
-        )
-    val advancement =
-        Bukkit.getUnsafe().loadAdvancement(key, createSocialLikeToastJson(icon, text))
-            ?: throw IllegalStateException("Bukkit returned null advancement for $key")
-
-    player.getAdvancementProgress(advancement).awardCriteria(TOAST_CRITERION)
-    Bukkit.getScheduler()
-        .runTaskLater(
-            plugin,
-            Runnable {
-              try {
-                Bukkit.getPlayer(player.uniqueId)
-                    ?.getAdvancementProgress(advancement)
-                    ?.takeIf { TOAST_CRITERION in it.awardedCriteria }
-                    ?.revokeCriteria(TOAST_CRITERION)
-              } finally {
-                Bukkit.getUnsafe().removeAdvancement(key)
-              }
-            },
-            20L,
-        )
-  }
-
-  private fun createSocialLikeToastJson(icon: ItemStack, text: String): String {
-    val title = text.ifBlank { "SocialLikes" }
-    val iconType = icon.type.takeIf { it.isItem } ?: Material.OAK_SIGN
-
-    return """
-      {
-        "criteria": {
-          "$TOAST_CRITERION": {
-            "trigger": "minecraft:impossible"
-          }
-        },
-        "display": {
-          "announce_to_chat": false,
-          "background": "minecraft:gui/advancements/backgrounds/adventure",
-          "description": ${legacyJsonText("\n§7A notification.")},
-          "frame": "task",
-          "hidden": true,
-          "icon": {
-            "count": 1,
-            "id": "${iconType.key.asString()}"
-          },
-          "show_toast": true,
-          "title": ${legacyJsonText(title)}
-        },
-        "requirements": [
-          [
-            "$TOAST_CRITERION"
-          ]
-        ],
-        "sends_telemetry_event": false
-      }
-      """
-        .trimIndent()
-  }
-
-  private fun legacyJsonText(text: String): String {
-    return gsonComponentSerializer.serialize(legacySectionSerializer.deserialize(text))
   }
 
   private fun String.withoutLegacyColorCodes(): String {


### PR DESCRIPTION
## Summary
- replace SocialLikes3 like-toast registration with direct `ClientboundUpdateAdvancementsPacket` add/remove packets
- avoid `Bukkit.getUnsafe().loadAdvancement` / `removeAdvancement`, which reloads server advancement state for online players
- keep the existing ActionBar fallback if packet toast delivery fails

## Scope note
- This PR intentionally does not include `plugins/OyasaiToken` or any OyasaiToken-related dependency changes.

## Validation
- `nix fmt`
- `git diff --check`
- `nix develop --command gradle :plugins:SocialLikes3:build`
- `nix flake check -L`
- Local Paper server startup with SocialLikes3 enabled
- Manual local like-toast click test
- Local Spark profiler/health check reviewed; links intentionally omitted from this public PR body
