### PR TITLE
fix(sociallikes3): preserve hanging sign recovery

### DIFF
--- a/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/Events.kt
+++ b/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/Events.kt
@@ -173,6 +173,9 @@ object Events : Listener {
   /** このPluginの看板内部データKey */
   val idKey = NamespacedKey(plugin, "SocialLikes_ID")
 
+  /** 再取得したSL看板アイテムの復元用データKey */
+  val slSignItemIdKey = NamespacedKey(plugin, "sociallikes_id")
+
   /** 運営チェックマーク */
   val checkMarkRegex = Regex("""✓""")
 
@@ -438,60 +441,67 @@ object Events : Listener {
     // if (!Geyser.api().isBedrockPlayer(e.player.uniqueId)) return
     if (!signRegex.containsMatchIn(e.itemInHand.type.name.uppercase())) return
     val meta = e.itemInHand.itemMeta ?: return
-    if (!sl3Regex.containsMatchIn(meta.asString)) return
-
-    val slIDStr = sl3Regex.find(meta.asString)?.value ?: return
-    val id = slIDStr.replace("\"sociallikes3:sociallikes_id\":", "").toIntOrNull() ?: return
+    val sourceSign = (meta as? BlockStateMeta)?.blockState as? Sign
+    val sourceSignId =
+        sourceSign?.persistentDataContainer?.get(slSignItemIdKey, PersistentDataType.INTEGER)
+            ?: sourceSign?.persistentDataContainer?.get(idKey, PersistentDataType.INTEGER)
+    val id =
+        sourceSignId
+            ?: meta.persistentDataContainer.get(slSignItemIdKey, PersistentDataType.INTEGER)
+            ?: legacySLSignItemId(meta.asString)
+            ?: return
     val slData = Data.getSLData(id) ?: return
+    val sourceSignForRestore = sourceSign.takeIf { sourceSignId != null }
 
-    val sign = e.blockPlaced.state
-    if (sign !is Sign) return
+    if (e.blockPlaced.state !is Sign) return
     object : BukkitRunnable() {
           override fun run() {
-            beSignTask(sign, slData)
+            val sign = e.blockPlaced.state as? Sign ?: return
+            beSignTask(sign, slData, sourceSignForRestore)
           }
         }
         .runTaskLater(plugin, 1)
     // e.isCancelled = true
   }
 
-  private fun beSignTask(sign: Sign, slData: SLData) {
-    /*val signData = sign.blockData
-    val rotation = if (signData is Rotatable) {
-        signData.rotation.name
+  private fun legacySLSignItemId(metaAsString: String): Int? {
+    val slIDStr = sl3Regex.find(metaAsString)?.value ?: return null
+    return slIDStr.replace("\"sociallikes3:sociallikes_id\":", "").toIntOrNull()
+  }
+
+  private fun beSignTask(sign: Sign, slData: SLData, sourceSign: Sign?) {
+    if (sourceSign != null) {
+      copySignSide(sourceSign, sign, Side.FRONT)
+      copySignSide(sourceSign, sign, Side.BACK)
+      sign.isWaxed = sourceSign.isWaxed
     } else {
-        null
+      sign.getSide(Side.FRONT).apply {
+        setLine(0, Tools.socialLikesLOGO)
+        setLine(1, "&a".color() + slData.title)
+        setLine(2, "&f${Bukkit.getOfflinePlayer(slData.owner).name}".color())
+        setLine(
+            3,
+            "&7Likes&8: &6${slData.likes.count()}${if (slData.check){" &e✓"}else{""}}".color(),
+        )
+      }
+      sign.isWaxed = true
     }
-    val face = if (signData is Directional) {
-        signData.facing
-    } else {
-        null
-    }*/
 
-    // sign.type = newMaterial
-    // sign.update(true,false)
-
-    /*val data = sign.blockData
-    if (data is Rotatable) {
-        data.rotation = BlockFace.valueOf(rotation!!)
-    }
-    if (data is Directional) {
-        data.facing = face!!
-    }
-    sign.blockData = data*/
-    // sign.update(true,false)
-
-    sign.getSide(Side.FRONT).apply {
-      setLine(0, Tools.socialLikesLOGO)
-      setLine(1, "&a".color() + slData.title)
-      setLine(2, "&f${Bukkit.getOfflinePlayer(slData.owner).name}".color())
-      setLine(3, "&7Likes&8: &6${slData.likes.count()}${if (slData.check){" &e✓"}else{""}}".color())
-    }
-    // sign.update(true,false)
-
-    sign.isWaxed = true
-    sign.persistentDataContainer.set(idKey, PersistentDataType.INTEGER, slData.id)
+    val id =
+        sourceSign?.persistentDataContainer?.get(slSignItemIdKey, PersistentDataType.INTEGER)
+            ?: sourceSign?.persistentDataContainer?.get(idKey, PersistentDataType.INTEGER)
+            ?: slData.id
+    sign.persistentDataContainer.set(idKey, PersistentDataType.INTEGER, id)
+    sign.persistentDataContainer.set(slSignItemIdKey, PersistentDataType.INTEGER, id)
     sign.update(true)
+  }
+
+  private fun copySignSide(sourceSign: Sign, targetSign: Sign, side: Side) {
+    val sourceSide = sourceSign.getSide(side)
+    val targetSide = targetSign.getSide(side)
+    (0 until 4).forEach { index -> targetSide.line(index, sourceSide.line(index)) }
+    targetSide.isGlowingText = sourceSide.isGlowingText
+    targetSide.color = sourceSide.color
   }
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)

--- a/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/command/SLSignGet.kt
+++ b/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/command/SLSignGet.kt
@@ -1,14 +1,21 @@
 package com.github.srain3.sociallikes.command
 
+import com.github.srain3.sociallikes.Events
 import com.github.srain3.sociallikes.Tools
 import com.github.srain3.sociallikes.Tools.color
 import com.github.srain3.sociallikes.datas.Data
 import com.github.srain3.sociallikes.datas.SLData
 import org.bukkit.Bukkit
+import org.bukkit.Material
+import org.bukkit.block.Sign
+import org.bukkit.block.sign.Side
 import org.bukkit.command.Command
 import org.bukkit.command.CommandExecutor
 import org.bukkit.command.CommandSender
 import org.bukkit.entity.Player
+import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.meta.BlockStateMeta
+import org.bukkit.persistence.PersistentDataType
 
 object SLSignGet : CommandExecutor {
   override fun onCommand(
@@ -29,15 +36,8 @@ object SLSignGet : CommandExecutor {
               return true
             }
     if (slData.owner == sender.uniqueId || sender.isOp) {
-      if (args.size == 2) {
-        if (args[1].lowercase() == "hanging") {
-          genSignItem(slData, sender, true)
-        } else {
-          genSignItem(slData, sender, false)
-        }
-      } else {
-        genSignItem(slData, sender, false)
-      }
+      val requestedHanging = args.getOrNull(1)?.let { it.lowercase() == "hanging" }
+      genSignItem(slData, sender, requestedHanging)
       sender.sendMessage(
           Tools.socialLikesLOGO + "&r Like看板のアイテムを渡しました! 設置して/slupdateを行ってください".color()
       )
@@ -47,48 +47,59 @@ object SLSignGet : CommandExecutor {
     return true
   }
 
-  private fun genSignItem(slData: SLData, player: Player, hanging: Boolean) {
-    if (slData.check) {
-      Bukkit.dispatchCommand(
-          Bukkit.getConsoleSender(),
-          "minecraft:give ${player.name} ${
-          if (hanging) {
-            "oak_hanging_sign"
-          } else {
-            "oak_sign"
-          }
-        }[item_name='\"${escapeForNBT(slData.title)}\"',lore=['[{\"color\":\"gray\",\"text\":\"設置後に\"},{\"color\":\"yellow\",\"text\":\"/slupdate\"}]'],minecraft:block_entity_data={PublicBukkitValues:{\"sociallikes3:sociallikes_id\":${slData.id}},id:\"minecraft:sign\",is_waxed:1b,front_text:{messages:[[{\"text\":\"(\",\"color\":\"dark_gray\"},{\"text\":\"Social\",\"color\":\"dark_purple\"},{\"text\":\"Likes\",\"color\":\"gray\"},{\"text\":\")\",\"color\":\"dark_gray\"}],{\"text\":\"${
-          escapeForNBT(
-            slData.title
-          )
-        }\",\"color\":\"green\"},{\"text\":\"${
-          Bukkit.getOfflinePlayer(
-            slData.owner
-          ).name
-        }\",\"color\":\"white\"},[{\"text\":\"Likes\",\"color\":\"gray\"},{\"text\":\":\",\"color\":\"dark_gray\"},{\"text\":\"${slData.likes.count()}\",\"color\":\"gold\"},{\"text\":\" ✓\",\"color\":\"yellow\"}]]}}] 1",
-      )
-    } else {
-      Bukkit.dispatchCommand(
-          Bukkit.getConsoleSender(),
-          "minecraft:give ${player.name} ${
-          if (hanging) {
-            "oak_hanging_sign"
-          } else {
-            "oak_sign"
-          }
-        }[item_name='\"${escapeForNBT(slData.title)}\"',lore=['[{\"color\":\"gray\",\"text\":\"設置後に\"},{\"color\":\"yellow\",\"text\":\"/slupdate\"}]'],minecraft:block_entity_data={PublicBukkitValues:{\"sociallikes3:sociallikes_id\":${slData.id}},id:\"minecraft:sign\",is_waxed:1b,front_text:{messages:[[{\"text\":\"(\",\"color\":\"dark_gray\"},{\"text\":\"Social\",\"color\":\"dark_purple\"},{\"text\":\"Likes\",\"color\":\"gray\"},{\"text\":\")\",\"color\":\"dark_gray\"}],{\"text\":\"${
-          escapeForNBT(
-            slData.title
-          )
-        }\",\"color\":\"green\"},{\"text\":\"${
-          Bukkit.getOfflinePlayer(
-            slData.owner
-          ).name
-        }\",\"color\":\"white\"},[{\"text\":\"Likes\",\"color\":\"gray\"},{\"text\":\":\",\"color\":\"dark_gray\"},{\"text\":\"${slData.likes.count()}\",\"color\":\"gold\"}]]}}] 1",
-      )
-    }
+  private fun genSignItem(slData: SLData, player: Player, requestedHanging: Boolean?) {
+    val itemMaterial = resolveSignItemMaterial(slData, requestedHanging)
+    val item = ItemStack(itemMaterial)
+    val meta = item.itemMeta as? BlockStateMeta ?: return
+    val signState = meta.blockState as? Sign ?: return
+
+    writeSLSignLines(signState, slData)
+    signState.isWaxed = true
+    signState.persistentDataContainer.set(
+        Events.slSignItemIdKey,
+        PersistentDataType.INTEGER,
+        slData.id,
+    )
+    meta.blockState = signState
+    meta.persistentDataContainer.set(Events.slSignItemIdKey, PersistentDataType.INTEGER, slData.id)
+    meta.setDisplayName("&a${slData.title}".color())
+    meta.lore = listOf("&7設置後に&e/slupdate".color())
+    item.itemMeta = meta
+
+    player.inventory.addItem(item)
   }
 
-  private fun escapeForNBT(input: String): String =
-      input.replace("\\", "\\\\").replace("\"", "\\\"").replace("'", "\\'").replace("§", "\\u00A7")
+  private fun resolveSignItemMaterial(slData: SLData, requestedHanging: Boolean?): Material {
+    val sourceMaterial = sourceSignMaterial(slData)
+    val woodName = sourceMaterial?.woodName() ?: "OAK"
+    val hanging = requestedHanging ?: sourceMaterial?.isHangingSignMaterial() ?: false
+    return Material.matchMaterial("$woodName${if (hanging) "_HANGING_SIGN" else "_SIGN"}")
+        ?: if (hanging) Material.OAK_HANGING_SIGN else Material.OAK_SIGN
+  }
+
+  private fun sourceSignMaterial(slData: SLData): Material? {
+    slData.loc.world ?: return null
+    val sourceState = slData.loc.block.state
+    return if (sourceState is Sign) sourceState.type else null
+  }
+
+  private fun Material.woodName(): String =
+      when {
+        name.endsWith("_WALL_HANGING_SIGN") -> name.removeSuffix("_WALL_HANGING_SIGN")
+        name.endsWith("_HANGING_SIGN") -> name.removeSuffix("_HANGING_SIGN")
+        name.endsWith("_WALL_SIGN") -> name.removeSuffix("_WALL_SIGN")
+        name.endsWith("_SIGN") -> name.removeSuffix("_SIGN")
+        else -> "OAK"
+      }
+
+  private fun Material.isHangingSignMaterial(): Boolean = name.contains("HANGING_SIGN")
+
+  private fun writeSLSignLines(sign: Sign, slData: SLData) {
+    sign.getSide(Side.FRONT).apply {
+      setLine(0, Tools.socialLikesLOGO)
+      setLine(1, "&a".color() + slData.title)
+      setLine(2, "&f${Bukkit.getOfflinePlayer(slData.owner).name}".color())
+      setLine(3, "&7Likes&8: &6${slData.likes.count()}${if (slData.check){" &e✓"}else{""}}".color())
+    }
+  }
 }

--- a/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/gui/SLSignSetting.kt
+++ b/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/gui/SLSignSetting.kt
@@ -35,13 +35,53 @@ import org.bukkit.persistence.PersistentDataType
 
 object SLSignSetting {
 
-  // 釣り看板かどうか
+  // 吊り看板かどうか
   private val hangingRegex = Regex("""HANGING""")
   // 壁付きかどうか
   private val wallRegex = Regex("""WALL""")
 
   val sltpSignKey = NamespacedKey(plugin, "SocialLikes_TPsign")
   val sltpSignUUIDKey = NamespacedKey(plugin, "SocialLikes_TPsign_owner")
+
+  private data class SignMaterialOption(
+      val itemMaterial: Material,
+      val woodName: String,
+      val displayName: String,
+      val loreName: String,
+      val x: Int,
+      val y: Int,
+  )
+
+  private val signMaterialOptions =
+      listOf(
+          SignMaterialOption(Material.OAK_SIGN, "OAK", "オーク", "オーク", 0, 0),
+          SignMaterialOption(Material.SPRUCE_SIGN, "SPRUCE", "トウヒ", "トウヒ", 1, 0),
+          SignMaterialOption(Material.BIRCH_SIGN, "BIRCH", "シラカバ", "シラカバ", 2, 0),
+          SignMaterialOption(Material.JUNGLE_SIGN, "JUNGLE", "ジャングル", "ジャングル", 3, 0),
+          SignMaterialOption(Material.ACACIA_SIGN, "ACACIA", "アカシア", "アカシア", 4, 0),
+          SignMaterialOption(Material.DARK_OAK_SIGN, "DARK_OAK", "ダークオーク", "ダークオーク", 5, 0),
+          SignMaterialOption(Material.MANGROVE_SIGN, "MANGROVE", "マングローブ", "マングローブ", 0, 1),
+          SignMaterialOption(Material.CHERRY_SIGN, "CHERRY", "サクラ", "サクラ", 1, 1),
+          SignMaterialOption(Material.BAMBOO_SIGN, "BAMBOO", "竹", "竹", 2, 1),
+          SignMaterialOption(Material.PALE_OAK_SIGN, "PALE_OAK", "ペールオーク", "ペールオーク", 3, 1),
+          SignMaterialOption(Material.CRIMSON_SIGN, "CRIMSON", "真紅", "真紅", 4, 1),
+          SignMaterialOption(Material.WARPED_SIGN, "WARPED", "歪んだ", "歪んだ木材", 5, 1),
+      )
+
+  private fun shapeSuffix(material: Material): String {
+    val name = material.name
+    val isHanging = hangingRegex.containsMatchIn(name)
+    val isWall = wallRegex.containsMatchIn(name)
+    return when {
+      isHanging && isWall -> "_WALL_HANGING_SIGN"
+      isHanging -> "_HANGING_SIGN"
+      isWall -> "_WALL_SIGN"
+      else -> "_SIGN"
+    }
+  }
+
+  private fun materialForCurrentShape(currentMaterial: Material, woodName: String): Material =
+      Material.valueOf("$woodName${shapeSuffix(currentMaterial)}")
 
   private fun asItemSignMaterial(material: Material): Material {
     val name = material.name
@@ -158,330 +198,23 @@ object SLSignSetting {
           0,
           2,
       )
-      addItem(
-          GuiItem(
-              ItemStack(Material.OAK_SIGN)
-                  .allFlag()
-                  .addText("&aオークの看板へ変更する", mutableListOf("&7材質をオークへ変えます"))
-          ) {
-            val oldMaterialName = sign.type.name
-            val newMaterial =
-                if (hangingRegex.containsMatchIn(oldMaterialName)) {
-                  if (wallRegex.containsMatchIn(oldMaterialName)) {
-                    Material.OAK_WALL_HANGING_SIGN
-                  } else {
-                    Material.OAK_HANGING_SIGN
-                  }
-                } else {
-                  if (wallRegex.containsMatchIn(oldMaterialName)) {
-                    Material.OAK_WALL_SIGN
-                  } else {
-                    Material.OAK_SIGN
-                  }
-                }
-            changeSignType(sign, newMaterial, slData.id)
-            it.whoClicked.closeInventory()
-          },
-          0,
-          0,
-      )
-      addItem(
-          GuiItem(
-              ItemStack(Material.SPRUCE_SIGN)
-                  .allFlag()
-                  .addText("&aトウヒの看板へ変更する", mutableListOf("&7材質をトウヒへ変えます"))
-          ) {
-            val oldMaterialName = sign.type.name
-            val newMaterial =
-                if (hangingRegex.containsMatchIn(oldMaterialName)) {
-                  if (wallRegex.containsMatchIn(oldMaterialName)) {
-                    Material.SPRUCE_WALL_HANGING_SIGN
-                  } else {
-                    Material.SPRUCE_HANGING_SIGN
-                  }
-                } else {
-                  if (wallRegex.containsMatchIn(oldMaterialName)) {
-                    Material.SPRUCE_WALL_SIGN
-                  } else {
-                    Material.SPRUCE_SIGN
-                  }
-                }
-            changeSignType(sign, newMaterial, slData.id)
-            it.whoClicked.closeInventory()
-          },
-          1,
-          0,
-      )
-      addItem(
-          GuiItem(
-              ItemStack(Material.BIRCH_SIGN)
-                  .allFlag()
-                  .addText("&aシラカバの看板へ変更する", mutableListOf("&7材質をシラカバへ変えます"))
-          ) {
-            val oldMaterialName = sign.type.name
-            val newMaterial =
-                if (hangingRegex.containsMatchIn(oldMaterialName)) {
-                  if (wallRegex.containsMatchIn(oldMaterialName)) {
-                    Material.BIRCH_WALL_HANGING_SIGN
-                  } else {
-                    Material.BIRCH_HANGING_SIGN
-                  }
-                } else {
-                  if (wallRegex.containsMatchIn(oldMaterialName)) {
-                    Material.BIRCH_WALL_SIGN
-                  } else {
-                    Material.BIRCH_SIGN
-                  }
-                }
-            changeSignType(sign, newMaterial, slData.id)
-            it.whoClicked.closeInventory()
-          },
-          2,
-          0,
-      )
-      addItem(
-          GuiItem(
-              ItemStack(Material.JUNGLE_SIGN)
-                  .allFlag()
-                  .addText("&aジャングルの看板へ変更する", mutableListOf("&7材質をジャングルへ変えます"))
-          ) {
-            val oldMaterialName = sign.type.name
-            val newMaterial =
-                if (hangingRegex.containsMatchIn(oldMaterialName)) {
-                  if (wallRegex.containsMatchIn(oldMaterialName)) {
-                    Material.JUNGLE_WALL_HANGING_SIGN
-                  } else {
-                    Material.JUNGLE_HANGING_SIGN
-                  }
-                } else {
-                  if (wallRegex.containsMatchIn(oldMaterialName)) {
-                    Material.JUNGLE_WALL_SIGN
-                  } else {
-                    Material.JUNGLE_SIGN
-                  }
-                }
-            changeSignType(sign, newMaterial, slData.id)
-            it.whoClicked.closeInventory()
-          },
-          3,
-          0,
-      )
-      addItem(
-          GuiItem(
-              ItemStack(Material.ACACIA_SIGN)
-                  .allFlag()
-                  .addText("&aアカシアの看板へ変更する", mutableListOf("&7材質をアカシアへ変えます"))
-          ) {
-            val oldMaterialName = sign.type.name
-            val newMaterial =
-                if (hangingRegex.containsMatchIn(oldMaterialName)) {
-                  if (wallRegex.containsMatchIn(oldMaterialName)) {
-                    Material.ACACIA_WALL_HANGING_SIGN
-                  } else {
-                    Material.ACACIA_HANGING_SIGN
-                  }
-                } else {
-                  if (wallRegex.containsMatchIn(oldMaterialName)) {
-                    Material.ACACIA_WALL_SIGN
-                  } else {
-                    Material.ACACIA_SIGN
-                  }
-                }
-            changeSignType(sign, newMaterial, slData.id)
-            it.whoClicked.closeInventory()
-          },
-          4,
-          0,
-      )
-      addItem(
-          GuiItem(
-              ItemStack(Material.DARK_OAK_SIGN)
-                  .allFlag()
-                  .addText("&aダークオークの看板へ変更する", mutableListOf("&7材質をダークオークへ変えます"))
-          ) {
-            val oldMaterialName = sign.type.name
-            val newMaterial =
-                if (hangingRegex.containsMatchIn(oldMaterialName)) {
-                  if (wallRegex.containsMatchIn(oldMaterialName)) {
-                    Material.DARK_OAK_WALL_HANGING_SIGN
-                  } else {
-                    Material.DARK_OAK_HANGING_SIGN
-                  }
-                } else {
-                  if (wallRegex.containsMatchIn(oldMaterialName)) {
-                    Material.DARK_OAK_WALL_SIGN
-                  } else {
-                    Material.DARK_OAK_SIGN
-                  }
-                }
-            changeSignType(sign, newMaterial, slData.id)
-            it.whoClicked.closeInventory()
-          },
-          5,
-          0,
-      )
-      addItem(
-          GuiItem(
-              ItemStack(Material.MANGROVE_SIGN)
-                  .allFlag()
-                  .addText("&aマングローブの看板へ変更する", mutableListOf("&7材質をマングローブへ変えます"))
-          ) {
-            val oldMaterialName = sign.type.name
-            val newMaterial =
-                if (hangingRegex.containsMatchIn(oldMaterialName)) {
-                  if (wallRegex.containsMatchIn(oldMaterialName)) {
-                    Material.MANGROVE_WALL_HANGING_SIGN
-                  } else {
-                    Material.MANGROVE_HANGING_SIGN
-                  }
-                } else {
-                  if (wallRegex.containsMatchIn(oldMaterialName)) {
-                    Material.MANGROVE_WALL_SIGN
-                  } else {
-                    Material.MANGROVE_SIGN
-                  }
-                }
-            changeSignType(sign, newMaterial, slData.id)
-            it.whoClicked.closeInventory()
-          },
-          0,
-          1,
-      )
-      addItem(
-          GuiItem(
-              ItemStack(Material.CHERRY_SIGN)
-                  .allFlag()
-                  .addText("&aサクラの看板へ変更する", mutableListOf("&7材質をサクラへ変えます"))
-          ) {
-            val oldMaterialName = sign.type.name
-            val newMaterial =
-                if (hangingRegex.containsMatchIn(oldMaterialName)) {
-                  if (wallRegex.containsMatchIn(oldMaterialName)) {
-                    Material.CHERRY_WALL_HANGING_SIGN
-                  } else {
-                    Material.CHERRY_HANGING_SIGN
-                  }
-                } else {
-                  if (wallRegex.containsMatchIn(oldMaterialName)) {
-                    Material.CHERRY_WALL_SIGN
-                  } else {
-                    Material.CHERRY_SIGN
-                  }
-                }
-            changeSignType(sign, newMaterial, slData.id)
-            it.whoClicked.closeInventory()
-          },
-          1,
-          1,
-      )
-      addItem(
-          GuiItem(
-              ItemStack(Material.BAMBOO_SIGN)
-                  .allFlag()
-                  .addText("&a竹の看板へ変更する", mutableListOf("&7材質を竹へ変えます"))
-          ) {
-            val oldMaterialName = sign.type.name
-            val newMaterial =
-                if (hangingRegex.containsMatchIn(oldMaterialName)) {
-                  if (wallRegex.containsMatchIn(oldMaterialName)) {
-                    Material.BAMBOO_WALL_HANGING_SIGN
-                  } else {
-                    Material.BAMBOO_HANGING_SIGN
-                  }
-                } else {
-                  if (wallRegex.containsMatchIn(oldMaterialName)) {
-                    Material.BAMBOO_WALL_SIGN
-                  } else {
-                    Material.BAMBOO_SIGN
-                  }
-                }
-            changeSignType(sign, newMaterial, slData.id)
-            it.whoClicked.closeInventory()
-          },
-          2,
-          1,
-      )
-      addItem(
-          GuiItem(
-              ItemStack(Material.PALE_OAK_SIGN)
-                  .allFlag()
-                  .addText("&aペールオークの看板へ変更する", mutableListOf("&7材質をペールオークへ変えます"))
-          ) {
-            val oldMaterialName = sign.type.name
-            val newMaterial =
-                if (hangingRegex.containsMatchIn(oldMaterialName)) {
-                  if (wallRegex.containsMatchIn(oldMaterialName)) {
-                    Material.PALE_OAK_WALL_HANGING_SIGN
-                  } else {
-                    Material.PALE_OAK_HANGING_SIGN
-                  }
-                } else {
-                  if (wallRegex.containsMatchIn(oldMaterialName)) {
-                    Material.PALE_OAK_WALL_SIGN
-                  } else {
-                    Material.PALE_OAK_SIGN
-                  }
-                }
-            changeSignType(sign, newMaterial, slData.id)
-            it.whoClicked.closeInventory()
-          },
-          3,
-          1,
-      )
-      addItem(
-          GuiItem(
-              ItemStack(Material.CRIMSON_SIGN)
-                  .allFlag()
-                  .addText("&a真紅の看板へ変更する", mutableListOf("&7材質を真紅へ変えます"))
-          ) {
-            val oldMaterialName = sign.type.name
-            val newMaterial =
-                if (hangingRegex.containsMatchIn(oldMaterialName)) {
-                  if (wallRegex.containsMatchIn(oldMaterialName)) {
-                    Material.CRIMSON_WALL_HANGING_SIGN
-                  } else {
-                    Material.CRIMSON_HANGING_SIGN
-                  }
-                } else {
-                  if (wallRegex.containsMatchIn(oldMaterialName)) {
-                    Material.CRIMSON_WALL_SIGN
-                  } else {
-                    Material.CRIMSON_SIGN
-                  }
-                }
-            changeSignType(sign, newMaterial, slData.id)
-            it.whoClicked.closeInventory()
-          },
-          4,
-          1,
-      )
-      addItem(
-          GuiItem(
-              ItemStack(Material.WARPED_SIGN)
-                  .allFlag()
-                  .addText("&a歪んだ看板へ変更する", mutableListOf("&7材質を歪んだ木材へ変えます"))
-          ) {
-            val oldMaterialName = sign.type.name
-            val newMaterial =
-                if (hangingRegex.containsMatchIn(oldMaterialName)) {
-                  if (wallRegex.containsMatchIn(oldMaterialName)) {
-                    Material.WARPED_WALL_HANGING_SIGN
-                  } else {
-                    Material.WARPED_HANGING_SIGN
-                  }
-                } else {
-                  if (wallRegex.containsMatchIn(oldMaterialName)) {
-                    Material.WARPED_WALL_SIGN
-                  } else {
-                    Material.WARPED_SIGN
-                  }
-                }
-            changeSignType(sign, newMaterial, slData.id)
-            it.whoClicked.closeInventory()
-          },
-          5,
-          1,
-      )
+      signMaterialOptions.forEach { option ->
+        addItem(
+            GuiItem(
+                ItemStack(option.itemMaterial)
+                    .allFlag()
+                    .addText(
+                        "&a${option.displayName}の看板へ変更する",
+                        mutableListOf("&7材質を${option.loreName}へ変えます"),
+                    )
+            ) {
+              changeSignType(sign, materialForCurrentShape(sign.type, option.woodName), slData.id)
+              it.whoClicked.closeInventory()
+            },
+            option.x,
+            option.y,
+        )
+      }
     }
     pane.apply {
       addItem(


### PR DESCRIPTION
## Summary
- preserve SL sign item metadata when recovering and replacing signs
- restore recovered sign lines, waxed state, and PDC from BlockStateMeta
- keep sign material changes shape-aware for standing, wall, hanging, and wall-hanging signs

## Tests
- `/nix/var/nix/profiles/default/bin/nix fmt`
- `/nix/var/nix/profiles/default/bin/nix develop --command gradle :plugins:SocialLikes3:build`
- `/nix/var/nix/profiles/default/bin/nix flake check -L`