### PR TITLE
chore(oyasaipets): remove verified dead code from OyasaiPetsUnified.kt

### DIFF
--- a/plugins/OyasaiPets/src/main/kotlin/me/marzipan/OyasaiPets/OyasaiPetsUnified.kt
+++ b/plugins/OyasaiPets/src/main/kotlin/me/marzipan/OyasaiPets/OyasaiPetsUnified.kt
@@ -90,9 +90,6 @@ class BigWolfPlugin : JavaPlugin(), CommandExecutor, TabCompleter {
   private val openedGuis = guiManager.openedPetGuis
   private val openedShopGuis = guiManager.openedShopGuis
   private val openedMainMenus = guiManager.openedMainMenus
-  // --- shopremoveall 確認待ち管理 ---
-  // --- abandon 確認待ち管理 ---
-  private val pendingAbandonConfirm = ConcurrentHashMap<UUID, Pair<Int, Long>>()
 
   // Cooldowns & Tasks
   private val mountCooldowns = ConcurrentHashMap<UUID, Long>()
@@ -366,7 +363,6 @@ class BigWolfPlugin : JavaPlugin(), CommandExecutor, TabCompleter {
               PetDataManager.clearPlayerCache(player.uniqueId)
               mountCooldowns.remove(player.uniqueId)
               dropCooldowns.remove(player.uniqueId)
-              pendingAbandonConfirm.remove(player.uniqueId)
               PetDebugger.disable(player.uniqueId)
             },
         )
@@ -970,12 +966,6 @@ object BigWolfConfig {
         3 -> skillBookUseCostLv3
         else -> 0
       }
-
-  @Deprecated(
-      "Use getSkillBookShopCost or getSkillBookUseCost instead",
-      replaceWith = ReplaceWith("getSkillBookUseCost(level)"),
-  )
-  fun getSkillBookCost(level: Int): Int = getSkillBookUseCost(level)
 
   /** 全コンフィグキーと現在値のリストを返す */
   fun asEntryList(): List<Pair<String, Any>> =
@@ -1918,7 +1908,7 @@ object ParrotFloatEffectRegistry {
 }
 
 // ===== File: debug/PetDebugger.kt =====
-/** /bigwolfop perf_debug で有効化するパフォーマンスデバッグ機能。 有効化中のプレイヤーに対してのみ動作し、無効時はほぼゼロコスト。 */
+/** パフォーマンスデバッグ用の集計機能。 有効化中のプレイヤーに対してのみ動作し、無効時はほぼゼロコスト。 */
 object PetDebugger {
   private val debugTargets = ConcurrentHashMap.newKeySet<UUID>()
 
@@ -1932,12 +1922,6 @@ object PetDebugger {
   )
 
   private val controlStats = ConcurrentHashMap<UUID, ControlStats>()
-
-  @Suppress("unused")
-  fun enable(playerUuid: UUID) {
-    debugTargets.add(playerUuid)
-    controlStats[playerUuid] = ControlStats()
-  }
 
   fun disable(playerUuid: UUID) {
     debugTargets.remove(playerUuid)
@@ -2271,9 +2255,6 @@ var LivingEntity.temperament: String
 
 /** このペットが非定型かどうかを判定 */
 fun LivingEntity.isAtypical(): Boolean = temperament == "atypical"
-
-/** 指定されたプレイヤーがこのペットの飼い主かどうかを判定 */
-@Suppress("unused") fun LivingEntity.isOwnedBy(playerId: String): Boolean = ownerId == playerId
 
 fun String.containsDefaultPetMarker(): Boolean = this.contains("'s Big ") || this.contains("の大")
 
@@ -3706,16 +3687,6 @@ object TemperamentHelper {
   fun getLevelUpMultiplier(temperament: String): Double {
     return if (temperament == ATYPICAL) {
       BigWolfConfig.atypicalLevelUpBonus
-    } else {
-      1.0
-    }
-  }
-
-  /** 性質に応じた親密度上昇倍率を取得 */
-  @Suppress("unused")
-  fun getAffectionMultiplier(temperament: String): Double {
-    return if (temperament == ATYPICAL) {
-      BigWolfConfig.atypicalAffectionBonus
     } else {
       1.0
     }


### PR DESCRIPTION
## Summary
- OyasaiPets God Object整理プランのステップ1(安全なデッドコード削除)。Claude+Codex+Geminiの3者協議で「呼び出し元ゼロと確認できたものだけを削除し、経済的価値(トークン購入・所有権・交配)に関わるロジックとショップ機能には一切触れない」方針で合意
- 削除したもの(いずれもリポジトリ全体grepで参照ゼロを確認済み):
  - `pendingAbandonConfirm`変数とquit時のremove処理
  - `BigWolfConfig.getSkillBookCost(level)`(既に`@Deprecated`)
  - `PetDebugger.enable(playerUuid)`(デバッグ計測は常時無効だった)
  - `LivingEntity.isOwnedBy(playerId)`
  - `TemperamentHelper.getAffectionMultiplier(temperament)`
  - `PetDebugger`コメント内の到達不能な`perf_debug`コマンド言及
- `ShopSystem`/`ShopListener`(既存ワールド内のショップMOB購入受付処理)は一切変更していない

## Test plan
- [x] `./gradlew :plugins:OyasaiPets:compileKotlin` — BUILD SUCCESSFUL
- [x] `./gradlew :plugins:OyasaiPets:shadowJar` — OyasaiPets.jar生成確認済み
- [x] 削除した5シンボルについてリポジトリ全体を再grepし、参照が残っていないことをダブルチェック(旧仕様書ドキュメント`docs/docs.old`内の記述1件を除き、実コード上の参照ゼロ)
- [ ] 本番デプロイ後の実機動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)