### PR TITLE
fix(sociallikes): stop requesting Bedrock profile completion

### DIFF
--- a/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/gui/SLPlayerHeads.kt
+++ b/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/gui/SLPlayerHeads.kt
@@ -36,6 +36,10 @@ object SLPlayerHeads {
   }
 
   fun createHead(uuid: UUID, name: String, textureValue: String? = null): ItemStack {
+    if (textureValue == null && isFloodgatePseudoUUID(uuid)) {
+      return createBedrockFallbackItem(name)
+    }
+
     val item = ItemStack(Material.PLAYER_HEAD)
     val meta = item.itemMeta as SkullMeta
     val onlinePlayer = Bukkit.getPlayer(uuid)

--- a/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/gui/SLRankUp.kt
+++ b/plugins/SocialLikes3/src/main/kotlin/com/github/srain3/sociallikes/gui/SLRankUp.kt
@@ -21,7 +21,6 @@ import org.bukkit.Sound
 import org.bukkit.entity.Player
 import org.bukkit.event.inventory.InventoryClickEvent
 import org.bukkit.inventory.ItemStack
-import org.bukkit.inventory.meta.SkullMeta
 
 object SLRankUp {
   private val format = DateTimeFormatter.ofPattern("yyyy/MM/dd")
@@ -118,10 +117,7 @@ object SLRankUp {
           if (!rankFilter.contains(rank)) return@forEach
           if (!beforeTime.isBefore(rud.lastOnlineTime())) return@forEach
 
-          val item = ItemStack(Material.PLAYER_HEAD)
-          val meta = item.itemMeta as SkullMeta
-          meta.setOwningPlayer(player)
-          item.itemMeta = meta
+          val item = SLPlayerHeads.createHead(player.uniqueId, player.name ?: "Unknown")
 
           item.allFlag()
           item.addText(


### PR DESCRIPTION
統合版の疑似 UUID にもオフラインプレイヤーを所有者として設定しており、Paper がその頭部プロフィールを Mojang に補完問い合わせしていました。
統合版（Floodgate）の疑似 UUID は、スキン情報がない限り SkullMeta にプロフィールを設定しないよう変更しました。これにより Paper が Mojang のプロフィール API へ補完問い合わせせず、429 警告を防げます。
RankUp GUI 側の頭部生成も同じ安全な処理に統一しました。