### PR TITLE
fix(oyasaiutilities): fix creative mark disappearing issue

### DIFF
--- a/plugins/OyasaiUtilities/src/main/kotlin/icu/oyasai/utilities/Main.kt
+++ b/plugins/OyasaiUtilities/src/main/kotlin/icu/oyasai/utilities/Main.kt
@@ -46,6 +46,7 @@ class Main : JavaPlugin() {
     AdminBP.onDisable()
     Pita.onDisable() // Pitaの無効化
     TimerObj.onDisable()
+    CreativeManagement.onDisable()
     DebugOnBE.onDisable()
   }
 }

--- a/plugins/OyasaiUtilities/src/main/kotlin/icu/oyasai/utilities/creative_management/CreativeBlockStore.kt
+++ b/plugins/OyasaiUtilities/src/main/kotlin/icu/oyasai/utilities/creative_management/CreativeBlockStore.kt
@@ -1,0 +1,83 @@
+package icu.oyasai.utilities.creative_management
+
+import icu.oyasai.utilities.OyasaiUtilities.plugin
+import java.util.UUID
+import org.bukkit.Chunk
+import org.bukkit.NamespacedKey
+import org.bukkit.block.Block
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.world.ChunkUnloadEvent
+import org.bukkit.persistence.PersistentDataType
+
+/**
+ * クリエイティブ設置ブロックの印をチャンク PDC に保存する。
+ *
+ * Bukkit Metadata と異なり、チャンクのワールドデータと一緒に保存されるため、再起動や
+ * チャンクのアンロード後も残る。チャンクごとに整数配列を一つだけ保存し、メモリ上では
+ * Set に展開するので、個々のブロックを走査せずに判定できる。
+ */
+object CreativeBlockStore : Listener {
+  private val markerKey = NamespacedKey(plugin, "creative-block-positions")
+  private val cache = mutableMapOf<ChunkId, MutableSet<Int>>()
+
+  fun isMarked(block: Block): Boolean = markers(block.chunk).contains(pack(block))
+
+  fun mark(block: Block) {
+    val chunk = block.chunk
+    val markers = markers(chunk)
+    if (markers.add(pack(block))) persist(chunk, markers)
+  }
+
+  fun remove(block: Block) {
+    val chunk = block.chunk
+    val markers = markers(chunk)
+    if (markers.remove(pack(block))) persist(chunk, markers)
+  }
+
+  /** ピストン等による移動では、移動元を全て消してから移動先へ印を付ける。 */
+  fun move(blocks: List<Block>, offsetX: Int, offsetY: Int, offsetZ: Int) {
+    val markedBlocks = blocks.filter(::isMarked)
+    markedBlocks.forEach(::remove)
+    markedBlocks.forEach { mark(it.getRelative(offsetX, offsetY, offsetZ)) }
+  }
+
+  @EventHandler
+  fun onChunkUnload(event: ChunkUnloadEvent) {
+    cache.remove(ChunkId(event.chunk))
+  }
+
+  fun clearCache() {
+    cache.clear()
+  }
+
+  private fun markers(chunk: Chunk): MutableSet<Int> {
+    return cache.getOrPut(ChunkId(chunk)) {
+      chunk.persistentDataContainer
+        .get(markerKey, PersistentDataType.INTEGER_ARRAY)
+        ?.toMutableSet()
+        ?: mutableSetOf()
+    }
+  }
+
+  private fun persist(chunk: Chunk, markers: Set<Int>) {
+    if (markers.isEmpty()) {
+      chunk.persistentDataContainer.remove(markerKey)
+    } else {
+      chunk.persistentDataContainer.set(
+        markerKey,
+        PersistentDataType.INTEGER_ARRAY,
+        markers.sorted().toIntArray(),
+      )
+    }
+  }
+
+  private fun pack(block: Block): Int {
+    val relativeY = block.y - block.world.minHeight
+    return (relativeY shl 8) or ((block.z and 15) shl 4) or (block.x and 15)
+  }
+
+  private data class ChunkId(val worldId: UUID, val x: Int, val z: Int) {
+    constructor(chunk: Chunk) : this(chunk.world.uid, chunk.x, chunk.z)
+  }
+}

--- a/plugins/OyasaiUtilities/src/main/kotlin/icu/oyasai/utilities/creative_management/CreativeBlockStore.kt
+++ b/plugins/OyasaiUtilities/src/main/kotlin/icu/oyasai/utilities/creative_management/CreativeBlockStore.kt
@@ -13,9 +13,8 @@ import org.bukkit.persistence.PersistentDataType
 /**
  * クリエイティブ設置ブロックの印をチャンク PDC に保存する。
  *
- * Bukkit Metadata と異なり、チャンクのワールドデータと一緒に保存されるため、再起動や
- * チャンクのアンロード後も残る。チャンクごとに整数配列を一つだけ保存し、メモリ上では
- * Set に展開するので、個々のブロックを走査せずに判定できる。
+ * Bukkit Metadata と異なり、チャンクのワールドデータと一緒に保存されるため、再起動や チャンクのアンロード後も残る。チャンクごとに整数配列を一つだけ保存し、メモリ上では Set
+ * に展開するので、個々のブロックを走査せずに判定できる。
  */
 object CreativeBlockStore : Listener {
   private val markerKey = NamespacedKey(plugin, "creative-block-positions")
@@ -53,10 +52,8 @@ object CreativeBlockStore : Listener {
 
   private fun markers(chunk: Chunk): MutableSet<Int> {
     return cache.getOrPut(ChunkId(chunk)) {
-      chunk.persistentDataContainer
-        .get(markerKey, PersistentDataType.INTEGER_ARRAY)
-        ?.toMutableSet()
-        ?: mutableSetOf()
+      chunk.persistentDataContainer.get(markerKey, PersistentDataType.INTEGER_ARRAY)?.toMutableSet()
+          ?: mutableSetOf()
     }
   }
 
@@ -65,9 +62,9 @@ object CreativeBlockStore : Listener {
       chunk.persistentDataContainer.remove(markerKey)
     } else {
       chunk.persistentDataContainer.set(
-        markerKey,
-        PersistentDataType.INTEGER_ARRAY,
-        markers.sorted().toIntArray(),
+          markerKey,
+          PersistentDataType.INTEGER_ARRAY,
+          markers.sorted().toIntArray(),
       )
     }
   }

--- a/plugins/OyasaiUtilities/src/main/kotlin/icu/oyasai/utilities/creative_management/CreativeManagement.kt
+++ b/plugins/OyasaiUtilities/src/main/kotlin/icu/oyasai/utilities/creative_management/CreativeManagement.kt
@@ -7,5 +7,10 @@ object CreativeManagement {
     val server = OyasaiUtilities.plugin.server
     server.pluginManager.registerEvents(GetEvent, OyasaiUtilities.plugin)
     server.pluginManager.registerEvents(InventoryEvent, OyasaiUtilities.plugin)
+    server.pluginManager.registerEvents(CreativeBlockStore, OyasaiUtilities.plugin)
+  }
+
+  fun onDisable() {
+    CreativeBlockStore.clearCache()
   }
 }

--- a/plugins/OyasaiUtilities/src/main/kotlin/icu/oyasai/utilities/creative_management/GetEvent.kt
+++ b/plugins/OyasaiUtilities/src/main/kotlin/icu/oyasai/utilities/creative_management/GetEvent.kt
@@ -109,10 +109,10 @@ object GetEvent : Listener {
     }
     val block = e.clickedBlock ?: return
     if (
-      block.type == Material.CHISELED_BOOKSHELF ||
-      block.type == Material.DECORATED_POT ||
-      block.type == Material.CAMPFIRE ||
-      block.type == Material.SOUL_CAMPFIRE
+        block.type == Material.CHISELED_BOOKSHELF ||
+            block.type == Material.DECORATED_POT ||
+            block.type == Material.CAMPFIRE ||
+            block.type == Material.SOUL_CAMPFIRE
     ) {
       if (CreativeBlockStore.isMarked(block)) {
         // クリエブロック
@@ -253,8 +253,8 @@ object GetEvent : Listener {
       return
     }
     if (
-      e.item.itemStack.persistentDataContainer.has(NAMESPACE) ||
-      e.item.persistentDataContainer.has(NAMESPACE)
+        e.item.itemStack.persistentDataContainer.has(NAMESPACE) ||
+            e.item.persistentDataContainer.has(NAMESPACE)
     ) {
       if (e.player.gameMode != GameMode.CREATIVE) {
         // クリエじゃないので拾えない
@@ -287,18 +287,18 @@ object GetEvent : Listener {
     if (i1.persistentDataContainer.has(NAMESPACE) && i2.persistentDataContainer.has(NAMESPACE)) {
       return
     } else if (
-      (!i1.persistentDataContainer.has(NAMESPACE) && !i2.persistentDataContainer.has(NAMESPACE))
+        (!i1.persistentDataContainer.has(NAMESPACE) && !i2.persistentDataContainer.has(NAMESPACE))
     ) {
       return
     }
     if (
-      i1.itemStack.persistentDataContainer.has(NAMESPACE) &&
-      i2.itemStack.persistentDataContainer.has(NAMESPACE)
+        i1.itemStack.persistentDataContainer.has(NAMESPACE) &&
+            i2.itemStack.persistentDataContainer.has(NAMESPACE)
     ) {
       return
     } else if (
-      (!i1.itemStack.persistentDataContainer.has(NAMESPACE) &&
-        !i2.itemStack.persistentDataContainer.has(NAMESPACE))
+        (!i1.itemStack.persistentDataContainer.has(NAMESPACE) &&
+            !i2.itemStack.persistentDataContainer.has(NAMESPACE))
     ) {
       return
     }
@@ -319,15 +319,15 @@ object GetEvent : Listener {
     if (e.isCancelled) return
     if (e.action != PlayerItemFrameChangeEvent.ItemFrameChangeAction.PLACE) {
       if (
-        e.action == PlayerItemFrameChangeEvent.ItemFrameChangeAction.REMOVE &&
-        e.player.gameMode == GameMode.CREATIVE
+          e.action == PlayerItemFrameChangeEvent.ItemFrameChangeAction.REMOVE &&
+              e.player.gameMode == GameMode.CREATIVE
       ) {
         if (!e.itemStack.persistentDataContainer.has(NAMESPACE)) {
           // サバイバルアイテムを外した場合
           val item = e.itemStack.clone()
           val loc = e.itemFrame.location.clone().add(0.0, 0.125, 0.0)
           val vec =
-            Vector(0.0, 0.2, 0.15).rotateAroundY(Math.toRadians(Random.nextDouble(0.0, 360.0)))
+              Vector(0.0, 0.2, 0.15).rotateAroundY(Math.toRadians(Random.nextDouble(0.0, 360.0)))
           loc.world.dropItemNaturally(loc, item).velocity = vec
         }
       }

--- a/plugins/OyasaiUtilities/src/main/kotlin/icu/oyasai/utilities/creative_management/GetEvent.kt
+++ b/plugins/OyasaiUtilities/src/main/kotlin/icu/oyasai/utilities/creative_management/GetEvent.kt
@@ -12,6 +12,7 @@ import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
 import org.bukkit.event.block.*
+import org.bukkit.event.entity.EntityExplodeEvent
 import org.bukkit.event.entity.ItemMergeEvent
 import org.bukkit.event.inventory.InventoryClickEvent
 import org.bukkit.event.player.PlayerArmorStandManipulateEvent
@@ -20,17 +21,12 @@ import org.bukkit.event.player.PlayerDropItemEvent
 import org.bukkit.event.player.PlayerInteractEvent
 import org.bukkit.inventory.BlockInventoryHolder
 import org.bukkit.inventory.meta.SpawnEggMeta
-import org.bukkit.metadata.MetadataValue
 import org.bukkit.persistence.PersistentDataType
-import org.bukkit.plugin.Plugin
 import org.bukkit.util.Vector
 
 object GetEvent : Listener {
-  /** クリエ関連用Meta(TAG) */
-  private const val META_TAG = "CreativeBlock"
-
   /** クリエ関連用Namespace */
-  private val NAMESPACE = NamespacedKey(plugin, META_TAG)
+  private val NAMESPACE = NamespacedKey(plugin, "CreativeBlock")
 
   /** 失敗時の音 */
   private fun Player.missSound() {
@@ -48,8 +44,8 @@ object GetEvent : Listener {
     if (e.items.isEmpty()) {
       if (e.player.gameMode != GameMode.CREATIVE) return
     }
-    if (!e.block.state.hasMetadata(META_TAG)) return
-    e.block.state.removeMetadata(META_TAG, plugin)
+    if (!CreativeBlockStore.isMarked(e.block)) return
+    CreativeBlockStore.remove(e.block)
     e.isCancelled = true
   }
 
@@ -58,55 +54,42 @@ object GetEvent : Listener {
   fun blockBuildEvent(e: BlockPlaceEvent) {
     if (e.isCancelled) return
     if (e.blockPlaced.type.isAir) return
-    if (e.player.gameMode != GameMode.CREATIVE) return
-    e.blockPlaced.state.setMetadata(
-        META_TAG,
-        object : MetadataValue {
-          override fun value(): Any? {
-            return true
-          }
+    if (e.player.gameMode == GameMode.CREATIVE) {
+      CreativeBlockStore.mark(e.blockPlaced)
+    } else {
+      // 以前に壊れた落下ブロック等の古い印が、この座標に再利用されないようにする。
+      CreativeBlockStore.remove(e.blockPlaced)
+    }
+  }
 
-          override fun asInt(): Int {
-            return 1
-          }
+  @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+  fun pistonExtendEvent(e: BlockPistonExtendEvent) {
+    CreativeBlockStore.move(e.blocks, e.direction.modX, e.direction.modY, e.direction.modZ)
+  }
 
-          override fun asFloat(): Float {
-            return 1F
-          }
+  @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+  fun pistonRetractEvent(e: BlockPistonRetractEvent) {
+    CreativeBlockStore.move(e.blocks, e.direction.modX, e.direction.modY, e.direction.modZ)
+  }
 
-          override fun asDouble(): Double {
-            return 1.0
-          }
+  @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+  fun blockExplodeEvent(e: BlockExplodeEvent) {
+    e.blockList().forEach(CreativeBlockStore::remove)
+  }
 
-          override fun asLong(): Long {
-            return 1L
-          }
+  @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+  fun entityExplodeEvent(e: EntityExplodeEvent) {
+    e.blockList().forEach(CreativeBlockStore::remove)
+  }
 
-          override fun asShort(): Short {
-            return 1
-          }
+  @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+  fun blockBurnEvent(e: BlockBurnEvent) {
+    CreativeBlockStore.remove(e.block)
+  }
 
-          override fun asByte(): Byte {
-            return 1
-          }
-
-          override fun asBoolean(): Boolean {
-            return true
-          }
-
-          override fun asString(): String {
-            return "true"
-          }
-
-          override fun getOwningPlugin(): Plugin? {
-            return plugin
-          }
-
-          override fun invalidate() {
-            return
-          }
-        },
-    )
+  @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+  fun blockFadeEvent(e: BlockFadeEvent) {
+    CreativeBlockStore.remove(e.block)
   }
 
   /** ブロックをクリックしたときの制御(色々なブロック) */
@@ -126,12 +109,12 @@ object GetEvent : Listener {
     }
     val block = e.clickedBlock ?: return
     if (
-        block.type == Material.CHISELED_BOOKSHELF ||
-            block.type == Material.DECORATED_POT ||
-            block.type == Material.CAMPFIRE ||
-            block.type == Material.SOUL_CAMPFIRE
+      block.type == Material.CHISELED_BOOKSHELF ||
+      block.type == Material.DECORATED_POT ||
+      block.type == Material.CAMPFIRE ||
+      block.type == Material.SOUL_CAMPFIRE
     ) {
-      if (block.hasMetadata(META_TAG)) {
+      if (CreativeBlockStore.isMarked(block)) {
         // クリエブロック
         if (e.player.gameMode != GameMode.CREATIVE) {
           // クリエじゃないので弄れない
@@ -165,7 +148,7 @@ object GetEvent : Listener {
 
     if (isBlockHolder || isDoubleChest) {
       // ブロックにあるインベントリの場合
-      if (loc.block.state.hasMetadata(META_TAG)) {
+      if (CreativeBlockStore.isMarked(loc.block)) {
         // クリエブロックのインベントリ
         if (isSurvival) {
           // クリエじゃないので弄れない
@@ -194,7 +177,7 @@ object GetEvent : Listener {
   @EventHandler(priority = EventPriority.HIGH)
   fun dispenseEvent(e: BlockDispenseEvent) {
     if (e.isCancelled) return
-    if (!e.block.state.hasMetadata(META_TAG)) return
+    if (!CreativeBlockStore.isMarked(e.block)) return
     val item = e.item.clone()
     if (item.itemMeta is SpawnEggMeta) {
       e.isCancelled = true
@@ -207,7 +190,7 @@ object GetEvent : Listener {
   @EventHandler(priority = EventPriority.HIGH)
   fun dispenseArmorEvent(e: BlockDispenseArmorEvent) {
     if (e.isCancelled) return
-    if (!e.block.state.hasMetadata(META_TAG)) return
+    if (!CreativeBlockStore.isMarked(e.block)) return
     val item = e.item.clone()
     item.editMeta { it.persistentDataContainer.set(NAMESPACE, PersistentDataType.BOOLEAN, true) }
     e.item = item
@@ -216,7 +199,7 @@ object GetEvent : Listener {
   @EventHandler(priority = EventPriority.HIGH)
   fun cookEvent(e: BlockCookEvent) {
     if (e.isCancelled) return
-    if (!e.block.state.hasMetadata(META_TAG)) return
+    if (!CreativeBlockStore.isMarked(e.block)) return
     val item = e.result.clone()
     item.editMeta { it.persistentDataContainer.set(NAMESPACE, PersistentDataType.BOOLEAN, true) }
     e.result = item
@@ -270,8 +253,8 @@ object GetEvent : Listener {
       return
     }
     if (
-        e.item.itemStack.persistentDataContainer.has(NAMESPACE) ||
-            e.item.persistentDataContainer.has(NAMESPACE)
+      e.item.itemStack.persistentDataContainer.has(NAMESPACE) ||
+      e.item.persistentDataContainer.has(NAMESPACE)
     ) {
       if (e.player.gameMode != GameMode.CREATIVE) {
         // クリエじゃないので拾えない
@@ -304,18 +287,18 @@ object GetEvent : Listener {
     if (i1.persistentDataContainer.has(NAMESPACE) && i2.persistentDataContainer.has(NAMESPACE)) {
       return
     } else if (
-        (!i1.persistentDataContainer.has(NAMESPACE) && !i2.persistentDataContainer.has(NAMESPACE))
+      (!i1.persistentDataContainer.has(NAMESPACE) && !i2.persistentDataContainer.has(NAMESPACE))
     ) {
       return
     }
     if (
-        i1.itemStack.persistentDataContainer.has(NAMESPACE) &&
-            i2.itemStack.persistentDataContainer.has(NAMESPACE)
+      i1.itemStack.persistentDataContainer.has(NAMESPACE) &&
+      i2.itemStack.persistentDataContainer.has(NAMESPACE)
     ) {
       return
     } else if (
-        (!i1.itemStack.persistentDataContainer.has(NAMESPACE) &&
-            !i2.itemStack.persistentDataContainer.has(NAMESPACE))
+      (!i1.itemStack.persistentDataContainer.has(NAMESPACE) &&
+        !i2.itemStack.persistentDataContainer.has(NAMESPACE))
     ) {
       return
     }
@@ -336,15 +319,15 @@ object GetEvent : Listener {
     if (e.isCancelled) return
     if (e.action != PlayerItemFrameChangeEvent.ItemFrameChangeAction.PLACE) {
       if (
-          e.action == PlayerItemFrameChangeEvent.ItemFrameChangeAction.REMOVE &&
-              e.player.gameMode == GameMode.CREATIVE
+        e.action == PlayerItemFrameChangeEvent.ItemFrameChangeAction.REMOVE &&
+        e.player.gameMode == GameMode.CREATIVE
       ) {
         if (!e.itemStack.persistentDataContainer.has(NAMESPACE)) {
           // サバイバルアイテムを外した場合
           val item = e.itemStack.clone()
           val loc = e.itemFrame.location.clone().add(0.0, 0.125, 0.0)
           val vec =
-              Vector(0.0, 0.2, 0.15).rotateAroundY(Math.toRadians(Random.nextDouble(0.0, 360.0)))
+            Vector(0.0, 0.2, 0.15).rotateAroundY(Math.toRadians(Random.nextDouble(0.0, 360.0)))
           loc.world.dropItemNaturally(loc, item).velocity = vec
         }
       }


### PR DESCRIPTION
CreativeManagementの保存データのMetadataはメモリ上だけの一時情報なので再起動で消えます。
そこで再起動後も残るチャンク PDC 保存へ置き換えました。
チャンクごとに印の座標を整数配列 1 個として保存し、起動時の全ブロック走査はしません。
判定はロード済みチャンクのメモリキャッシュ上で行うため、通常操作のラグは小さい設計です。