### PR TITLE
fix(velocity): remove skinsrestorer from proxy

### DIFF
--- a/packages/oyasai-velocity.nix
+++ b/packages/oyasai-velocity.nix
@@ -13,7 +13,6 @@ oyasaiVelocity {
     # keep-sorted start
     floodgate
     geyser
-    skinsrestorer
     venturechat
     # keep-sorted end
   ];


### PR DESCRIPTION
## Summary
- Remove `skinsrestorer` from `packages/oyasai-velocity.nix` so Velocity no longer runs SkinsRestorer in proxy mode.
- This addresses the donor-only skin command bypass where Velocity-side SkinsRestorer saw permission checks as undefined because LuckPerms was not present on the proxy, then allowed the command via fallback behavior.
- Scope is intentionally limited to `packages/oyasai-velocity.nix` only.

## Remaining tasks
- Decide how `skinsrestorer` should be handled in `packages/oyasai-minecraft-lobby.nix`.
- Update production main server `SkinsRestorer/config.yml` and restart main: set `server.proxyMode.detection` to `DISABLED` and `server.proxyMode.api` to `false`.
- Confirm migration for the 11 skin setting data entries that currently exist only on Velocity.

## Review / deployment note
- Do not merge or deploy yet; this PR is waiting for review.

## Tests
- `nix fmt`
- `git diff --check`
- `nix flake check -L`
