### PR TITLE
fix(infra): use dns name for docker deploy host

### DIFF
--- a/packages/oyasai-cdktf/src/stacks/platform-services.ts
+++ b/packages/oyasai-cdktf/src/stacks/platform-services.ts
@@ -37,7 +37,7 @@ export class PlatformServices extends OyasaiPlatformTerraformStack {
       this.createCloudBackend();
 
       new DockerProvider(this, id, {
-        host: `tcp://${platformInfra.ipv4}:2376`,
+        host: "tcp://oyasai.io:2376",
         caMaterial: secrets.get("TLS_CA_PEM"),
         certMaterial: secrets.get("TLS_CERT_PEM"),
         keyMaterial: secrets.get("TLS_KEY_PEM"),


### PR DESCRIPTION
## Summary
- connect the Docker provider through `oyasai.io` instead of the current public IP literal
- avoid TLS SAN mismatches when the public IP changes, since the server certificate already includes `DNS:oyasai.io`

## Tests
- `/nix/var/nix/profiles/default/bin/nix fmt`
- `git diff --check`
- `/nix/var/nix/profiles/default/bin/nix flake check -L` failed while building existing Node dependency `readdirp` before CDKTF completed
- `/nix/var/nix/profiles/default/bin/nix build .#oyasai-cdktf -L --no-link` failed while building existing Node dependency `universalify` before `oyasai-cdktf` completed

## Notes
- This touches a CODEOWNERS-owned CDKTF file and should require @shunueda approval.